### PR TITLE
Linked .detach() mention.

### DIFF
--- a/entries/empty.xml
+++ b/entries/empty.xml
@@ -17,7 +17,7 @@
 &lt;/div&gt;</pre>
 <p>If we had any number of nested elements inside <code>&lt;div class="hello"&gt;</code>, they would be removed, too. </p>
   <p>To avoid memory leaks, jQuery removes other constructs such as data and event handlers from the child elements before removing the elements themselves.</p>
-  <p>If you want to remove elements without destroying their data or event handlers (so they can be re-added later), use .detach() instead.</p>
+  <p>If you want to remove elements without destroying their data or event handlers (so they can be re-added later), use <a href="/detach/">.detach()</a> instead.</p>
   </longdesc>
   <example>
     <desc>Removes all child nodes (including text nodes) from all paragraphs</desc>


### PR DESCRIPTION
In some of the docs I've noticed links made with absolute URLs -- is there a reason for that?
