### PR TITLE
Changed "grunt" to "grunt deploy" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The `xmllint` and `xsltproc` utilities need to be in your path. If you are on Wi
 1. `npm install`
 2. `cp config-sample.json config.json`
 3. Edit config.json per https://github.com/scottgonzalez/grunt-wordpress#config
-4. `grunt`
+4. `grunt deploy`
 
 ## Style Guidelines
 


### PR DESCRIPTION
It's not obvious that the `grunt deploy` task needs to be run to get the content
into the WordPress database.
