### PR TITLE
Updates the Events header on the Types page so the anchor link works and

### DIFF
--- a/pages/Types.html
+++ b/pages/Types.html
@@ -529,10 +529,10 @@ c.print(); // 1
 </p>
 <p>If Selector is specified as the type of an argument, it accepts everything that the jQuery constructor accepts, eg. Strings, Elements, Lists of Elements.
 </p>
-<a href="http://docs.jquery.com/Events/jQuery.Event" title="Events/jQuery.Event">Event</a> </h2>
+<h2 id="Event">Event</h2>
 <p>jQuery's event system normalizes the event object according to W3C standards. The event object is guaranteed to be passed to the event handler (no checks for window.event required). It normalizes the target, relatedTarget, which, metaKey and pageX/Y properties and provides both stopPropagation() and preventDefault() methods.
 </p>
-<p>Those properties are all documented, and accompanied by examples, on the <a href="http://docs.jquery.com/Events/jQuery.Event" title="Events/jQuery.Event">Event</a> page.
+<p>Those properties are all documented, and accompanied by examples, on the <a href="http://api.jquery.com/category/events/event-object/" title="Events">Event object</a> page.
 </p>
 <p>The standard events in the Document Object Model are: <code>blur, focus, load, resize, scroll, unload, beforeunload, click, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress,</code> and <code>keyup</code>. Since the DOM event names have predefined meanings for some elements, using them for other purposes is not recommended. jQuery's event model can trigger an event by any name on an element, and it is propagated up the DOM tree to which that element belongs, if any.
 </p>


### PR DESCRIPTION
the header is correctly formatted, fixes the link in the events
paragraph to point to the Event object page in the api docs
