### PR TITLE
Simple format fix at .index() method page.

### DIFF
--- a/entries/index.xml
+++ b/entries/index.xml
@@ -35,8 +35,8 @@
     <pre><code>
 var listItem = document.getElementById('bar');
 alert('Index: ' + $('li').index(listItem));
-We get back the zero-based position of the list item:
 </code></pre>
+    <p>We get back the zero-based position of the list item:</p>
     <p>
       <span class="output">Index: 1</span>
     </p>


### PR DESCRIPTION
I was browsing the documentation and then saw that in http://api.jquery.com/index/ , in the first example inside the detail section, the sentence "We get back the zero-based position of the list item:" was not inside p tags, so I put the sentence inside tags to get it formatted like the other similar sentences.

I think that the commit says that many lines were altered because I'm in windows. If that is a problem, I can try to fix it somehow.

Thanks for the attention.
