### PR TITLE
Fix broken code example at entries/length.xml

### DIFF
--- a/entries/length.xml
+++ b/entries/length.xml
@@ -15,7 +15,8 @@
   var n = $("div").length;
   $("span").text("There are " + n + " divs." +
                  "Click to add more.");
-}).trigger('click'); // trigger the click to start]]></code>
+}).trigger('click'); // trigger the click to start
+]]></code>
     <css><![CDATA[
   body { cursor:pointer; }
   div { width:50px; height:30px; margin:5px; float:left;


### PR DESCRIPTION
The comment at the last line causes the example script to be loaded automatically in a broken state on window.onload.

The generated code ends up looking like this:

``` javascript
window.onload = function() {$(document.body).click(function () {
  $(document.body).append($("<div>"));
  var n = $("div").length;
  $("span").text("There are " + n + " divs." +
                 "Click to add more.");
}).trigger('click'); // trigger the click to start};
```

Thus the ending curly brace } gets commented out and it results in a script error.
