### PR TITLE
Fix incorrect argument type for dataFilter

### DIFF
--- a/entries/jQuery.ajax.xml
+++ b/entries/jQuery.ajax.xml
@@ -60,7 +60,7 @@
         <desc>Data to be sent to the server. It is converted to a query string, if not already a string. It's appended to the url for GET-requests. See <code>processData</code> option to prevent this automatic processing. Object must be Key/Value pairs. If value is an Array, jQuery serializes multiple values with same key based on the value of the <code>traditional</code> setting (described below).</desc>
       </property>
       <property name="dataFilter" type="Function">
-        <argument name="data" type="PlainObject"/>
+        <argument name="data" type="String"/>
         <argument name="type" type="String"/>
         <return type="Object"/>
         <desc>A function to be used to handle the raw response data of XMLHttpRequest.This is a pre-filtering function to sanitize the response. You should return the sanitized data. The function accepts two arguments: The raw data returned from the server and the 'dataType' parameter.</desc>


### PR DESCRIPTION
Correct me if I'm wrong, but `data` is a string, not an object.
