### PR TITLE
Added a .data(obj) example

### DIFF
--- a/entries/data.xml
+++ b/entries/data.xml
@@ -23,12 +23,12 @@
       <p>The <code>.data()</code> method allows us to attach data of any type to DOM elements in a way that is safe from circular references and therefore from memory leaks.</p>
       <p> We can set several distinct values for a single element and retrieve them later:</p>
       <pre><code>
-$('body').data('foo', 52);
-$('body').data('bar', { myType: 'test', count: 40 });
-$('body').data({ baz: [ 1, 2, 3 ] });
+$("body").data("foo", 52);
+$("body").data("bar", { myType: "test", count: 40 });
+$("body").data({ baz: [ 1, 2, 3 ] });
 
-$('body').data('foo'); // 52
-$('body').data(); // {foo: 52, bar: { myType: 'test', count: 40 }, baz: [ 1, 2, 3 ] }
+$("body").data("foo"); // 52
+$("body").data(); // { foo: 52, bar: { myType: "test", count: 40 }, baz: [ 1, 2, 3 ] }
 </code></pre>
       <p>In jQuery 1.4.3 setting an element's data object with <code>.data(obj)</code> extends the data previously stored with that element. jQuery itself uses the <code>.data()</code> method to save information under the names 'events' and 'handle', and also reserves any data name starting with an underscore ('_') for internal use.</p>
       <p>Prior to jQuery 1.4.3 (starting in jQuery 1.4) the .data() method completely replaced all data, instead of just extending the data object. If you are using third-party plugins it may not be advisable to completely replace the element's data object, since plugins may have also set data.</p>


### PR DESCRIPTION
The documentation was missing this example. So now the code block looks like this:

``` javascript
$('body').data('foo', 52);
$('body').data('bar', { myType: 'test', count: 40 });
$('body').data({ baz: [ 1, 2, 3 ] });

$('body').data('foo'); // 52
$('body').data(); // {foo: 52, bar: { myType: 'test', count: 40 }, baz: [ 1, 2, 3 ] }
```
