### PR TITLE
Add removed notices to the removed props/methods

### DIFF
--- a/entries/die.xml
+++ b/entries/die.xml
@@ -50,5 +50,6 @@ $("p").die("click", foo); // ... foo will no longer be called.]]></code>
   <category slug="version/1.4.1"/>
   <category slug="version/1.4.3"/>
   <category slug="deprecated/deprecated-1.7"/>
+  <category slug="removed"/>
 </entry>
 

--- a/entries/jQuery.sub.xml
+++ b/entries/jQuery.sub.xml
@@ -95,4 +95,5 @@ $(document).ready(function() {
   <category slug="core"/>
   <category slug="version/1.5"/>
   <category slug="deprecated/deprecated-1.7"/>
+  <category slug="removed"/>
 </entry>

--- a/entries/live.xml
+++ b/entries/live.xml
@@ -105,4 +105,5 @@ $("p").live({
   <category slug="events/event-handler-attachment"/>
   <category slug="version/1.3"/>
   <category slug="deprecated/deprecated-1.7"/>
+  <category slug="removed"/>
 </entry>

--- a/entries/toggle-event.xml
+++ b/entries/toggle-event.xml
@@ -58,4 +58,5 @@
   <category slug="events/mouse-events"/>
   <category slug="version/1.0"/>
   <category slug="deprecated/deprecated-1.8"/>
+  <category slug="removed"/>
 </entry>


### PR DESCRIPTION
This modifies:
live
die
toggle-event
jQuery.sub

Adds the version the property was deprecated and removed in the
descriptions. Also adds the removed category slug
