### PR TITLE
Fix XSL Types path in builder

### DIFF
--- a/pages/Types.html
+++ b/pages/Types.html
@@ -112,7 +112,7 @@ var x = "";
 "&lt;a href=\"home\"&gt;Home&lt;/a&gt;"
 </code></pre>
 <h3 id="Built-in_Methods"> Built-in Methods </h3>
-<p>A string in JavaScript has some built-in methods to manipulate the string, though the result is always a new string - or something else, eg. split returns an <a href="http://api.jquery.com/Types#Array" title="Types">array</a>.
+<p>A string in JavaScript has some built-in methods to manipulate the string, though the result is always a new string - or something else, eg. split returns an <a href="http://api.jquery.com/Types/#Array" title="Types">array</a>.
 </p>
 <pre><code data-lang="javascript">"hello".charAt( 0 ) // "h"
 "hello".toUpperCase() // "HELLO"


### PR DESCRIPTION
Fixes issues #320, #309 and all other links throughout the documentation that links to a type on the /Types page.
