### PR TITLE
Refer to deferred.state instead of removed APIs

### DIFF
--- a/pages/Types.html
+++ b/pages/Types.html
@@ -613,7 +613,7 @@ c.print(); // 1
 <p>As of jQuery 1.5, the <a href="/category/deferred-object/">Deferred</a> object provides a way to register multiple callbacks into self-managed callback queues, invoke callback queues as appropriate, and relay the success or failure state of any synchronous or asynchronous function.
 </p>
 <h2 id="Promise"> Promise Object</h2>
-<p>This object provides a subset of the methods of the <a href="/category/deferred-object/">Deferred</a> object (<a href="/deferred.then/"><code>then</code></a>, <a href="/deferred.done/"><code>done</code></a>, <a href="/deferred.fail/"><code>fail</code></a>, <a href="/deferred.always/"><code>always</code></a>, <a href="/deferred.pipe/"><code>pipe</code></a>. <a href="/deferred.isResolved/"><code>isResolved</code></a>, and <a href="/deferred.isRejected/"><code>isRejected</code></a>) to prevent users from changing the state of the Deferred.
+<p>This object provides a subset of the methods of the <a href="/category/deferred-object/">Deferred</a> object (<a href="/deferred.then/"><code>then</code></a>, <a href="/deferred.done/"><code>done</code></a>, <a href="/deferred.fail/"><code>fail</code></a>, <a href="/deferred.always/"><code>always</code></a>, <a href="/deferred.pipe/"><code>pipe</code></a>, and <a href="/deferred.state/"><code>state</code></a>) to prevent users from changing the state of the Deferred.
 </p>
 <h2 id="Callbacks">Callbacks Object</h2>
 <p>A multi-purpose object that provides a powerful way to manage callback lists. It supports adding, removing, firing, and disabling callbacks. The Callbacks object is created and returned by the <code>$.Callbacks</code> function and subsequently returned by most of that function's methods. </p>


### PR DESCRIPTION
deferred.isResolved and .isRejected were deprecated then removed in favor of .state
