### PR TITLE
Note new sane 1.9+ behavior for disconnected elems, ref gh-240

### DIFF
--- a/entries/after.xml
+++ b/entries/after.xml
@@ -100,6 +100,7 @@ $( "p" ).first().after( $newdiv1, [ newdiv2, existingdiv1 ] );
     </code></pre>
     <p>Since <code>.after()</code> can accept any number of additional arguments, the same result can be achieved by passing in the three <code>&lt;div&gt;</code>s as three separate arguments, like so: <code>$( "p" ).first().after( $newdiv1, newdiv2, existingdiv1 )</code>. The type and number of arguments will largely depend on the elements that are collected in the code.</p>
   </longdesc>
+  <note id="disconnected-manipulation" type="additional" data-title=".after()"/>
   <note id="html-code-execution" type="additional"/>
   <example>
     <desc>Inserts some HTML after all paragraphs.</desc>

--- a/entries/before.xml
+++ b/entries/before.xml
@@ -80,6 +80,7 @@ $( "p" ).first().before( newdiv1, [ newdiv2, existingdiv1 ] );
     </code></pre>
     <p>Since <code>.before()</code> can accept any number of additional arguments, the same result can be achieved by passing in the three <code>&lt;div&gt;</code>s as three separate arguments, like so: <code>$( "p" ).first().before( $newdiv1, newdiv2, existingdiv1 )</code>. The type and number of arguments will largely depend on how you collect the elements in your code.</p>
   </longdesc>
+  <note id="disconnected-manipulation" type="additional" data-title=".before()"/>
   <note id="html-code-execution" type="additional"/>
   <example>
     <desc>Inserts some HTML before all paragraphs.</desc>

--- a/entries/replaceWith.xml
+++ b/entries/replaceWith.xml
@@ -63,18 +63,8 @@ $( "div.third" ).replaceWith( $( ".first" ) );
     </code></pre>
     <p>This example demonstrates that the selected element replaces the target by being moved from its old location, not by being cloned.</p>
     <p>The <code>.replaceWith()</code> method, like most jQuery methods, returns the jQuery object so that other methods can be chained onto it. However, it must be noted that the <em>original</em> jQuery object is returned. This object refers to the element that has been removed from the DOM, not the new element that has replaced it.</p>
-    <p>As of jQuery 1.4, <code>.replaceWith()</code> can also work on disconnected DOM nodes. For example, with the following code, <code>.replaceWith()</code> returns a jQuery set containing only a paragraph.:</p>
-    <pre><code>
-$( "&lt;div/&gt;" ).replaceWith( "&lt;p&gt;&lt;/p&gt;" );
-    </code></pre>
-    <p>The <code>.replaceWith()</code> method can also take a function as its argument:</p>
-    <pre><code>
-$( "div.container" ).replaceWith(function() {
-  return $( this ).contents();
-});
-    </code></pre>
-    <p>This results in <code>&lt;div class="container"&gt;</code> being replaced by its three child <code>&lt;div&gt;</code>s. The return value of the function may be an HTML string, DOM element, or jQuery object.</p>
   </longdesc>
+  <note id="disconnected-manipulation" type="additional" data-title=".replaceWith()"/>
   <example>
     <desc>On click, replace the button with a div containing the same word.</desc>
     <code><![CDATA[

--- a/notes.xsl
+++ b/notes.xsl
@@ -1,6 +1,9 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 <xsl:template name="note">
 	<xsl:choose>
+		<xsl:when test="@id = 'disconnected-manipulation'">
+			Prior to jQuery 1.9, <code><xsl:value-of select="@data-title"/></code> would attempt to add or change nodes in the current jQuery set if the first node in the set was not connected to a document, and in those cases return a new jQuery set rather than the original set. The method might or might not return a new result depending on the number or connectedness of its arguments! As of jQuery 1.9, these methods always return the original unmodified set and attempting to use .after(), .before(), or .replaceWith() on a node without a parent has no effect--that is, neither the set or the nodes it contains are changed.
+		</xsl:when>
 		<xsl:when test="@id = 'document-order'">
 			Selected elements are in the order of their appearance in the document.
 		</xsl:when>


### PR DESCRIPTION
Since behavior of older versions was flakey with disconnected elements I decided to just remove the reference rather than explain it, since people should avoid the practice with these APIs anyway
