### PR TITLE
Correct description of insertion cloning behavior

### DIFF
--- a/entries/after.xml
+++ b/entries/after.xml
@@ -60,7 +60,7 @@ $( ".container" ).after( $( "h2" ) );
 &lt;/div&gt;
 &lt;h2&gt;Greetings&lt;/h2&gt;
     </code></pre>
-    <p>If there is more than one target element, however, cloned copies of the inserted element will be created for each target after the first.</p>
+    <p><strong>Important</strong>: If there is more than one target element, however, cloned copies of the inserted element will be created for each target except for the last one.</p>
     <h4 id="disconnected-dom-nodes">Inserting Disconnected DOM nodes</h4>
     <p>As of jQuery 1.4, <code>.before()</code> and <code>.after()</code> will also work on disconnected DOM nodes. For example, given the following code:</p>
     <pre><code>$( "&lt;div&gt;&lt;/div&gt;" ).after( "&lt;p&gt;&lt;/p&gt;" );</code></pre>

--- a/entries/append.xml
+++ b/entries/append.xml
@@ -66,7 +66,7 @@ $( ".container" ).append( $( "h2" ) );
   &lt;h2&gt;Greetings&lt;/h2&gt;
 &lt;/div&gt;
     </code></pre>
-    <p>If there is more than one target element, however, cloned copies of the inserted element will be created for each target except for the last one.</p>
+    <p><strong>Important</strong>: If there is more than one target element, however, cloned copies of the inserted element will be created for each target except for the last one.</p>
     <h4 id="additional-arguments">Additional Arguments</h4>
     <p>Similar to other content-adding methods such as <code><a href="/prepend/">.prepend()</a></code> and <code><a href="/before/">.before()</a></code>, <code>.append()</code> also supports passing in multiple arguments as input. Supported input includes DOM elements, jQuery objects, HTML strings, and arrays of DOM elements.</p>
     <p>For example, the following will insert two new <code>&lt;div&gt;</code>s and an existing <code>&lt;div&gt;</code> as the last three child nodes of the body:</p>

--- a/entries/before.xml
+++ b/entries/before.xml
@@ -62,7 +62,7 @@ $( ".container" ).before( $( "h2" ) );
   &lt;div class="inner"&gt;Goodbye&lt;/div&gt;
 &lt;/div&gt;
     </code></pre>
-    <p>If there is more than one target element, however, cloned copies of the inserted element will be created for each target after the first.</p>
+    <p><strong>Important</strong>: If there is more than one target element, however, cloned copies of the inserted element will be created for each target except for the last one.</p>
     <p>In jQuery 1.4, <code>.before()</code> and <code>.after()</code> will also work on disconnected DOM nodes:</p>
     <pre><code>
 $( "&lt;div&gt;" ).before( "&lt;p&gt;&lt;/p&gt;" );

--- a/entries/prepend.xml
+++ b/entries/prepend.xml
@@ -66,7 +66,7 @@ $( ".container" ).prepend( $( "h2" ) );
     &lt;div class="inner"&gt;Goodbye&lt;/div&gt;
 &lt;/div&gt;
 </code></pre>
-    <p><strong>Important</strong>: If there is more than one target element, however, cloned copies of the inserted element will be created for each target after the first.</p>
+    <p><strong>Important</strong>: If there is more than one target element, however, cloned copies of the inserted element will be created for each target except for the last one.</p>
     <h4 id="additional-arguments">Additional Arguments</h4>
     <p>Similar to other content-adding methods such as <code><a href="/append/">.append()</a></code> and <code><a href="/before/">.before()</a></code>, <code>.prepend()</code> also supports passing in multiple arguments as input. Supported input includes DOM elements, jQuery objects, HTML strings, and arrays of DOM elements.</p>
     <p>For example, the following will insert two new <code>&lt;div&gt;</code>s and an existing <code>&lt;div&gt;</code> as the first three child nodes of the body:</p>


### PR DESCRIPTION
When an element is to be inserted in multiple locations in the DOM, all
four of these manipulation methods behave in the same way: they insert a
clone for all but the _last_ matched location.

From jQuery's implementation of the internal `domManip` method [1]:

> Use the original fragment for the last item instead of the first
> because it can end up being emptied incorrectly in certain situations
> (#8070).

[1]
https://github.com/jquery/jquery/blob/988d99ad278c2c9dc16c68f86bddc4df99dcd928/src/manipulation.js#L506-L522
