### PR TITLE
The docs for $.Callbacks().has indicate that an argument is required

### DIFF
--- a/entries/callbacks.has.xml
+++ b/entries/callbacks.has.xml
@@ -3,11 +3,11 @@
   <title>callbacks.has()</title>
   <signature>
     <added>1.7</added>
-    <argument name="callback" type="Function">
+    <argument name="callback" type="Function" optional="true">
       <desc>The callback to search for.</desc>
     </argument>
   </signature>
-  <desc>Determine whether a supplied callback is in a list</desc>
+  <desc>Determine whether or not the list has any callbacks attached. If a callback is provided as an argument, determine whether it is in a list</desc>
   <longdesc/>
   <example>
     <desc>Use <code>callbacks.has()</code> to check if a callback list contains a specific callback:</desc>


### PR DESCRIPTION
The documentation for $.Callbacks().has does not describe that the argument for the method is actually optional even though the source code for the method says otherwise[1].

I tried to add a suitable description to the method to indicate this. If it is not sufficient enough, I will go ahead and open an issue to update the docs instead.

[1] https://github.com/jquery/jquery/blob/master/src/callbacks.js#L145
