### PR TITLE
jQuery.boxModel should be listed as removed

### DIFF
--- a/entries/jQuery.boxModel.xml
+++ b/entries/jQuery.boxModel.xml
@@ -1,40 +1,13 @@
 <?xml version="1.0"?>
-<entry type="property" name="jQuery.boxModel" return="Boolean" deprecated="1.3">
+<entry type="property" name="jQuery.boxModel" return="Boolean" deprecated="1.3" removed="1.8">
   <title>jQuery.boxModel</title>
   <signature>
     <added>1.0</added>
   </signature>
-  <desc><strong>Deprecated in jQuery 1.3 (see <a href="/jQuery.support/">jQuery.support</a>)</strong>. States if the current page, in the user's browser, is being rendered using the <a href="http://www.w3.org/TR/REC-CSS2/box.html">W3C CSS Box Model</a>.</desc>
+  <desc>States if the current page, in the user's browser, is being rendered using the <a href="http://www.w3.org/TR/REC-CSS2/box.html">W3C CSS Box Model</a>. <strong>This property was removed in jQuery 1.8</strong>. Please try to use feature detection instead.</desc>
   <longdesc/>
-  <example>
-    <desc>Returns the box model for the iframe.</desc>
-    <code><![CDATA[
-$( "p" ).html( "The box model for this iframe is: <span>" +
-  jQuery.boxModel + "</span>" );
-]]></code>
-    <css><![CDATA[
-  p {
-    color: blue;
-    margin: 20px;
-  }
-  span {
-    color: red;
-  }
-]]></css>
-    <html><![CDATA[
-<p></p>
-]]></html>
-  </example>
-  <example>
-    <desc>Returns false if the page is in Quirks Mode in Internet Explorer</desc>
-    <code><![CDATA[
-$.boxModel
-]]></code>
-    <results><![CDATA[
-false
-]]></results>
-  </example>
   <category slug="utilities"/>
   <category slug="version/1.0"/>
   <category slug="deprecated/deprecated-1.3"/>
+  <category slug="removed"/>
 </entry>


### PR DESCRIPTION
[`jQuery.boxModel`](http://api.jquery.com/jQuery.boxModel/) was [removed in 1.8](/jquery/jquery/commit/c4e22ad8b5edd52ac78ec44bf7df8a7f37403623#diff-6d4bb79610683d9749d2cbb62e708d88). There should probably be a note in the doc to this effect, similar to what's in the doc for `jQuery.browser`:

> This property was removed in jQuery [1.8] and is available only through the jQuery.migrate plugin. Please try to use feature detection instead.

Possibly also add this to the "[Removed](http://api.jquery.com/category/removed/)" category?

`jQuery.support.boxModel` was also [removed in 1.10](/jquery/jquery/pull/1231), so perhaps the reference to `jQuery.support` should also be removed from the `boxModel` doc.
