### PR TITLE
cleanup examples

### DIFF
--- a/entries/deferred.then.xml
+++ b/entries/deferred.then.xml
@@ -113,7 +113,7 @@ $.Deferred(function( defer ) {
   filtered.fail(function( value ) {
     alert( "Value is ( 3*6 = ) 18: " + value );
   });
-}),
+});
 ]]></code>
   </example>
   <example>


### PR DESCRIPTION
use the shorter/prefered `$.Deferred(function)` notation in examples.
