### PR TITLE
fix second argument of deferred.notifyWith()

### DIFF
--- a/entries/deferred.notifyWith.xml
+++ b/entries/deferred.notifyWith.xml
@@ -8,9 +8,9 @@
         Context passed to the progressCallbacks as the <code>this</code> object.
       </desc>
     </argument>
-    <argument name="args" type="Object" optional="true">
+    <argument name="args" type="Array" optional="true">
       <desc>
-        Optional arguments that are passed to the progressCallbacks.
+        An optional array of arguments that are passed to the progressCallbacks.
       </desc>
     </argument>
   </signature>


### PR DESCRIPTION
This method takes an array as it’s second argument, just like deferred.resolveWith() and .deferred.rejectWith(). Currently it reads 

Type: Object
Optional arguments that are passed to the progressCallbacks.

It should read:

Type: Array
An optional array of arguments that are passed to the progressCallbacks.
