### PR TITLE
Integrate documentation for the ajax native datatype

### DIFF
--- a/entries/jQuery.ajax.xml
+++ b/entries/jQuery.ajax.xml
@@ -409,8 +409,24 @@ $.ajax({
 });
 ]]></code>
   </example>
+  <example>
+    <desc>Load a binary file as an ArrayBuffer, and cast it into an Uint8Array.</desc>
+    <code><![CDATA[
+$.ajax({
+  type: "GET",
+  url: "data.bin",
+  xhrFields: {
+    responseType: "arraybuffer"
+  }
+}).done(function ( data, jqXHR ) {
+  var array = new Uint8Array( data ); // Or, var array = new Uint8Array( jqXHR.responseNative );
+});
+]]></code>
+  </example>
   <category slug="ajax/low-level-interface"/>
   <category slug="version/1.0"/>
   <category slug="version/1.5"/>
   <category slug="version/1.5.1"/>
+  <category slug="version/1.12"/>
+  <category slug="version/2.2"/>
 </entry>


### PR DESCRIPTION
This pull request is for the documentation to the feature expressed in jquery/jquery#1525. A new feature that will be introduced in jquery 1.12/2.2. 

I have just pushed one commit, for the beginning of the documentation, as it is my first contribution. It contains just one example and new categories.

I need your feedback, before completing the remaining parts of the documentation. 
