### PR TITLE
Remove reference to responseHTML

### DIFF
--- a/entries/ajaxComplete.xml
+++ b/entries/ajaxComplete.xml
@@ -35,11 +35,11 @@ $( ".trigger" ).click(function() {
 $( document ).ajaxComplete(function( event, xhr, settings ) {
   if ( settings.url === "ajax/test.html" ) {
     $( ".log" ).text( "Triggered ajaxComplete handler. The result is " +
-      xhr.responseXML );
+      xhr.responseText );
   }
 });
     </code></pre>
-    <p><strong>Note:</strong> You can get the returned ajax contents by looking at <code>xhr.responseXML</code> for xml.</p>
+    <p><strong>Note:</strong> You can get the returned ajax contents by looking at <code>xhr.responseText</code>.</p>
   </longdesc>
   <note id="ajax-global-false" type="additional" data-title=".ajaxComplete()"/>
   <example>


### PR DESCRIPTION
As part of the work on the TypeScript jQuery typings we believe we found an erroneous reference to `responseHTML` in the API docs.  This PR removes reference to `responseHTML` in favour of `responseXML`.  You can read details of the rationale here:

https://github.com/borisyankov/DefinitelyTyped/pull/1471#issuecomment-31204115
