### PR TITLE
Update one.xml - Fixed ambiguity in sample code string

### DIFF
--- a/entries/one.xml
+++ b/entries/one.xml
@@ -48,7 +48,7 @@ $( "#foo" ).one( "click", function() {
   alert( "This will be displayed only once." );
 });
 $( "body" ).one( "click", "#foo", function() {
-  alert( "This displays if #foo is the first thing clicked in the body." );
+  alert( "This displays the first time #foo is clicked in the body." );
 });
     </code></pre>
     <p>After the code is executed, a click on the element with ID <code>foo</code> will display the alert. Subsequent clicks will do nothing. This code is equivalent to:</p>


### PR DESCRIPTION
Text on selector is ambigious to it's actual functionality. Changed from sounding like "the click on #foo had to be the first click in the document" to "the first click on #foo in the document"

jsfiddle for playground/proof: http://jsfiddle.net/B3zNn/1/
