### PR TITLE
jQuery.parseJSON: Function has multiple return types, not just Object.

### DIFF
--- a/entries/jQuery.parseJSON.xml
+++ b/entries/jQuery.parseJSON.xml
@@ -19,7 +19,7 @@
       <li><code>"{test: 1}"</code> (test does not have double quotes around it).</li>
       <li><code>"{'test': 1}"</code> ('test' is using single quotes instead of double quotes).</li>
       <li><code>"'test'"</code> ('test' is using single quotes instead of double quotes).</li>
-      <li><code>".1"</code> (a numbers must start with a digit; <code>"0.1"</code> would be valid).</li>
+      <li><code>".1"</code> (a number must start with a digit; <code>"0.1"</code> would be valid).</li>
       <li><code>"undefined"</code> (<code>undefined</code> cannot be represented in a JSON string; <code>null</code>, however, can be).</li>
       <li><code>"NaN"</code> (<code>NaN</code> cannot be represented in a JSON string; direct representation of <code>Infinity</code> is also not permitted).</li>
     </ul>


### PR DESCRIPTION
The return type is currently documented as [`Object`](//api.jquery.com/Types/#Object), with the description "...returns the resulting JavaScript object."

As this function is roughly equivalent to [`JSON.parse`](http://www.ecma-international.org/ecma-262/5.1/#sec-15.12.2), it technically produces an ECMAScript value, which, in addition to `Object` (or, really, [`PlainObject`](//api.jquery.com/Types/#PlainObject)), can also include `String`, `Number`, `Array`, `Boolean`, or `null`. These multiple return types should be explicitly mentioned on the return type.

Shall I attach a PR to make this change and update the description? To further clarify, perhaps another example could be added? (Related, minor issue: There's a rogue line break towards the end of the [current example](//api.jquery.com/jquery.parsejson/#entry-examples)...)
