### PR TITLE
Notes that replaceAll() and replaceWith() removes data associated with the removed nodes

### DIFF
--- a/entries/replaceAll.xml
+++ b/entries/replaceAll.xml
@@ -44,6 +44,7 @@ $( ".first" ).replaceAll( ".third" );
     </code></pre>
     <p>From this example, we can see that the selected element replaces the target by being moved from its old location, not by being cloned.</p>
   </longdesc>
+  <note id="removes-data" type="additional" data-title=".replaceAll()"/>
   <example>
     <desc>Replace all the paragraphs with bold words.</desc>
     <code><![CDATA[

--- a/entries/replaceWith.xml
+++ b/entries/replaceWith.xml
@@ -64,6 +64,7 @@ $( "div.third" ).replaceWith( $( ".first" ) );
     <p>This example demonstrates that the selected element replaces the target by being moved from its old location, not by being cloned.</p>
     <p>The <code>.replaceWith()</code> method, like most jQuery methods, returns the jQuery object so that other methods can be chained onto it. However, it must be noted that the <em>original</em> jQuery object is returned. This object refers to the element that has been removed from the DOM, not the new element that has replaced it.</p>
   </longdesc>
+  <note id="removes-data" type="additional" data-title=".replaceWith()"/>
   <note id="disconnected-manipulation" type="additional" data-title=".replaceWith()"/>
   <example>
     <desc>On click, replace the button with a div containing the same word.</desc>

--- a/notes.xsl
+++ b/notes.xsl
@@ -7,6 +7,9 @@
 		<xsl:when test="@id = 'disconnected-manipulation'">
 			Prior to jQuery 1.9, <code><xsl:value-of select="@data-title"/></code> would attempt to add or change nodes in the current jQuery set if the first node in the set was not connected to a document, and in those cases return a new jQuery set rather than the original set. The method might or might not have returned a new result depending on the number or connectedness of its arguments! As of jQuery 1.9, <code>.after()</code>, <code>.before()</code>, and <code>.replaceWith()</code> always return the original unmodified set. Attempting to use these methods on a node without a parent has no effect—that is, neither the set nor the nodes it contains are changed.
 		</xsl:when>
+		<xsl:when test="@id = 'removes-data'">
+			The <code><xsl:value-of select="@data-title"/></code> method removes all data and event handlers associated with the removed nodes.
+		</xsl:when>
 		<xsl:when test="@id = 'document-order'">
 			Selected elements are in the order of their appearance in the document.
 		</xsl:when>


### PR DESCRIPTION
... also changes use of "corollary" to "similar", as it seemed kind-of-awkward, and "similar" is easier to read for non-native speakers.
