### PR TITLE
Fixed a wrong difference and added another feature

### DIFF
--- a/entries/triggerHandler.xml
+++ b/entries/triggerHandler.xml
@@ -14,12 +14,13 @@
   <longdesc>
     <p>The <code>.triggerHandler()</code> method behaves similarly to <code>.trigger()</code>, with the following exceptions:</p>
     <ul>
-      <li>The <code>.triggerHandler()</code> method does not cause the default behavior of an event to occur (such as a form submission).</li>
+      <li>The <code>.triggerHandler()</code> method does not attempt to invoke the property of the same name as the event name as a method (a behavior that may cause the default behavior of an event to occur in some objects. For example, using <code>trigger("submit")</code> on a form - triggers the <code>submit</code> and also submits the form, as a result of invoking the <code>submit()</code> method of the form).</li>
       <li>While <code>.trigger()</code> will operate on all elements matched by the jQuery object, <code>.triggerHandler()</code> only affects the first matched element.</li>
       <li>Events triggered with <code>.triggerHandler()</code> do not bubble up the DOM hierarchy; if they are not handled by the target element directly, they do nothing.</li>
       <li>Instead of returning the jQuery object (to allow chaining), <code>.triggerHandler()</code> returns whatever value was returned by the last handler it caused to be executed. If no handlers are triggered, it returns <code>undefined</code></li>
     </ul>
     <p>For more information on this method, see the discussion for <code><a href="/trigger/">.trigger()</a></code>.</p>
+    <div class="warning"><strong>Note:</strong> Like <code>.trigger()</code>, if a triggered event name matches the name of a property on the object, prefixed by <code>on</code> (like, triggering <code>click</code> on <code>window</code> that has a non null <code>onclick</code> method), jQuery will attempt to invoke the property as a method.</div>
   </longdesc>
   <example>
     <desc>If you called .triggerHandler() on a focus event - the browser's default focus action would not be triggered, only the event handlers bound to the focus event.</desc>


### PR DESCRIPTION
1. .trigger() does not cause the default action to occur. Instead, it invokes the property of the same name as the event as a method. If this happens to cause the default action to occur - great - but this is not what it actually does.
2. .trigger() and .triggerHandler() invoke the on(event-type) method of the object as well ($(form).trigger("submit") calls form.onsubmit(...) as well).
