### PR TITLE
jQuery.browser should appear in the "Removed" category

### DIFF
--- a/entries/jQuery.browser.xml
+++ b/entries/jQuery.browser.xml
@@ -48,6 +48,7 @@ $.browser.msie;
     <category slug="version/1.0"/>
     <category slug="version/1.1.3"/>
     <category slug="deprecated/deprecated-1.3"/>
+    <category slug="removed"/>
   </entry>
   <entry type="property" name="jQuery.browser.version" return="String" deprecated="1.3" removed="1.9">
     <signature>


### PR DESCRIPTION
It is listed as removed but does not appear in the "[Removed](http://api.jquery.com/category/removed/)" category. Looks like it's just missing a category slug?
