### PR TITLE
documenting  that on() handler accepts .trigger() args #472

### DIFF
--- a/entries/on.xml
+++ b/entries/on.xml
@@ -139,8 +139,8 @@ $( "form" ).on( "submit", function( event ) {
   <example>
     <desc>Pass data to the event handler using the second argument to <code>.trigger()</code></desc>
     <code><![CDATA[
-$( "div" ).on( "click", function( event, extraParameter ) {
-  alert( "Hello, " + extraParameter.name );
+$( "div" ).on( "click", function( event, person ) {
+  alert( "Hello, " + person.name );
 });
 $( "div" ).trigger( "click", { name: "Jim" } );
 ]]></code>


### PR DESCRIPTION
See #472 for the complete story. Basically;
1. Added `extraParameter` to the signature, and added further documentation as to how it works. It uses the `rest="true"` vararg attribute, which currently doesn't _show_ anything, but support is being added in https://github.com/jquery/grunt-jquery-content/issues/56
2. Added examples of using `on()` and `trigger()`.
3. Various tidyings

... all separated into separate commits.
