### PR TITLE
Removing incorrect jQuery XHR example from $.when() docs. Adding documentation on the arguments passed to done/ fail callbacks.

### DIFF
--- a/entries/jQuery.when.xml
+++ b/entries/jQuery.when.xml
@@ -34,7 +34,7 @@ $.when( d1, d2 ).done(function ( v1, v2 ) {
 d1.resolve( "Fish" );
 d2.resolve( "Pizza" );
     </code></pre>
-    <p>In the event a Deferred was resolved with no value, the corresponding doneCallback argument will be undefined. If a Deferred resolved to a single value, the corresponding argument will hold that value. If the case where a Deferred resolved to multiple values, the corresponding argument will be an array of those values. For example:</p>
+    <p>In the event a Deferred was resolved with no value, the corresponding doneCallback argument will be undefined. If a Deferred resolved to a single value, the corresponding argument will hold that value. In the case where a Deferred resolved to multiple values, the corresponding argument will be an array of those values. For example:</p>
     <pre><code>
 var d1 = new $.Deferred();
 var d2 = new $.Deferred();


### PR DESCRIPTION
Rationale for removing the XHR example rather than correcting it is that an equivalent example is also provided at the end of the documentation, and I struggled to fit the example into the new form, which includes documentation on the values passed to the master-Deferred doneCallback, which was previously undocumented.

This would complete #262 (or otherwise make it redundant).

I've also taken the opportunity to change occurrences of `jQuery.when`, to the recommended style guideline `jQuery.when()`
