### PR TITLE
Entries marked as removed should appear in the Removed category

### DIFF
--- a/entries/deferred.isRejected.xml
+++ b/entries/deferred.isRejected.xml
@@ -13,4 +13,5 @@
   <category slug="deferred-object"/>
   <category slug="version/1.5"/>
   <category slug="deprecated/deprecated-1.7"/>
+  <category slug="removed"/>
 </entry>

--- a/entries/deferred.isResolved.xml
+++ b/entries/deferred.isResolved.xml
@@ -13,4 +13,5 @@
   <category slug="deferred-object"/>
   <category slug="version/1.5"/>
   <category slug="deprecated/deprecated-1.7"/>
+  <category slug="removed"/>
 </entry>

--- a/entries/selector.xml
+++ b/entries/selector.xml
@@ -12,4 +12,5 @@
   <category slug="properties/global-jquery-object-properties"/>
   <category slug="version/1.3"/>
   <category slug="deprecated/deprecated-1.7"/>
+  <category slug="removed"/>
 </entry>


### PR DESCRIPTION
There appear to be at least 3 entries that have been removed but which do not appear in the [`Removed`](//api.jquery.com/category/removed/) section of the API: [`deferred.isRejected()`](//api.jquery.com/deferred.isRejected/), [`deferred.isResolved()`](//api.jquery.com/deferred.isResolved/), and [`.selector`](//api.jquery.com/selector/). They appear to be missing the proper category slug.
