### PR TITLE
README: link to Github Issues instead of bugs.jquery.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Referencing Bug Tracker Tickets
 
-* Pull requests for changes that were requested or recommended via the [jQuery Bug Tracker](http://bugs.jquery.com) should include a link back to the relevant ticket.
+* Pull requests for changes that were requested or recommended via the [jQuery Issue Tracker](https://github.com/jquery/jquery/issues) should include a link back to the relevant ticket.
 
 ## Building
 


### PR DESCRIPTION
Recently, `jquery/jquery` switched to github issues instead of Trac. See https://github.com/jquery/jquery/issues/1681
