### PR TITLE
Types: Add entry for QUnit's Assert type

### DIFF
--- a/pages/Types.html
+++ b/pages/Types.html
@@ -639,3 +639,5 @@ c.print(); // 1
 <p>A multi-purpose object that provides a powerful way to manage callback lists. It supports adding, removing, firing, and disabling callbacks. The Callbacks object is created and returned by the <code>$.Callbacks</code> function and subsequently returned by most of that function's methods. </p>
 <h2 id="XMLDocument">XML Document</h2>
 <p>A document object created by the browser's XML DOM parser, usually from a string representing XML. XML documents have different semantics than HTML documents, but most of the traversing and manipulation methods provided by jQuery will work with them.</p>
+<h2 id="Assert">Assert</h2>
+<p>A reference to or instance of the object holding all of QUnit's assertions. See the <a href="//api.qunitjs.com/QUnit.assert">API documentation for <code>QUnit.assert</code></a> for details.</p>


### PR DESCRIPTION
Ref jquery/api.qunitjs.com#58

This implements "1) We put all types on api.jquery.com, even if they have nothing to do with jQuery" from https://github.com/jquery/grunt-jquery-content/issues/54
