### PR TITLE
jQuery.getScript: Fix external link to jquery-color

### DIFF
--- a/entries/jQuery.getScript.xml
+++ b/entries/jQuery.getScript.xml
@@ -94,7 +94,7 @@ $.cachedScript( "ajax/test.js" ).done(function( script, textStatus ) {
   <example>
     <desc>Load the <a href="https://github.com/jquery/jquery-color">official jQuery Color Animation plugin</a> dynamically and bind some color animations to occur once the new functionality is loaded.</desc>
     <code><![CDATA[
-var url = "https://raw.githubusercontent.com/jquery/jquery-color/master/jquery.color.js";
+var url = "//code.jquery.com/color/jquery.color-git.js";
 $.getScript( url, function() {
   $( "#go" ).click(function() {
     $( ".block" )


### PR DESCRIPTION
GitHub's rawusercontent url's don't serve proper mime types, so we can use
the version of jQuery color found on code.jquery.com

Fixes #583
