### PR TITLE
clarify that :text selector is for <input>s, not DOM text nodes

### DIFF
--- a/entries/text-selector.xml
+++ b/entries/text-selector.xml
@@ -5,7 +5,7 @@
   <signature>
     <added>1.0</added>
   </signature>
-  <desc>Selects all elements of type text.</desc>
+  <desc>Selects all input elements of type text.</desc>
   <longdesc>
     <p><code>$( ":text" )</code> allows us to select all <code>&lt;input type="text"&gt;</code> elements. As with other pseudo-class selectors (those that begin with a ":") it is recommended to precede it with a tag name or some other selector; otherwise, the universal selector ( "*" ) is implied. In other words, the bare <code>$( ":text" )</code> is equivalent to <code>$( "*:text" )</code>, so <code>$( "input:text" )</code> should be used instead. </p>
     <p><strong>Note:</strong> As of jQuery 1.5.2, <code>:text</code> selects <code>input</code> elements that have no specified <code>type</code> attribute (in which case <code>type="text"</code> is implied).  </p>


### PR DESCRIPTION
If you're just scanning through the list of short descriptions, it sounds like `:text` might possibly relate to [DOM text nodes](https://developer.mozilla.org/en-US/docs/Web/API/Text) rather than `<input>`s.

This change attempts to clarify the description to avoid any such confusion.
