### PR TITLE
jQuery.get: fix default for `type` option

### DIFF
--- a/entries/jQuery.get.xml
+++ b/entries/jQuery.get.xml
@@ -4,7 +4,7 @@
   <signature>
     <added>3.0</added>
     <argument name="settings" type="PlainObject" optional="false">
-      <desc>A set of key/value pairs that configure the Ajax request. All properties except for <code>url</code> are optional. A default can be set for any option with <a href="/jQuery.ajaxSetup/">$.ajaxSetup()</a>. See <a href="/jquery.ajax/#jQuery-ajax-settings">jQuery.ajax( settings )</a> for a complete list of all settings. The type option will automatically be set to <code>POST</code>.</desc>
+      <desc>A set of key/value pairs that configure the Ajax request. All properties except for <code>url</code> are optional. A default can be set for any option with <a href="/jQuery.ajaxSetup/">$.ajaxSetup()</a>. See <a href="/jquery.ajax/#jQuery-ajax-settings">jQuery.ajax( settings )</a> for a complete list of all settings. The type option will automatically be set to <code>GET</code>.</desc>
     </argument>
   </signature>
   <signature>


### PR DESCRIPTION
Fix for a little thing that got in with https://github.com/jquery/api.jquery.com/commit/c24d60b33a3a62187addb85731d1eee0bb71e9d6.