### PR TITLE
outerHeight: document the method as a setter

### DIFF
--- a/entries/outerHeight.xml
+++ b/entries/outerHeight.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0"?>
+<entries>
+  <desc>Get the current computed height for the first element in the set of matched elements, including padding, border, and optionally margin. Returns a number (without "px") representation of the value or null if called on an empty set of elements.</desc>
 <entry type="method" name="outerHeight" return="Number">
   <title>.outerHeight()</title>
   <signature>
@@ -41,3 +43,63 @@ $( "p:last" ).text(
   <category slug="manipulation/style-properties"/>
   <category slug="version/1.2.6"/>
 </entry>
+
+<entry type="method" name="outerHeight" return="jQuery">
+  <signature>
+    <added>1.8.0</added>
+    <argument name="value">
+      <type name="String"/>
+      <type name="Number"/>
+      <desc>A number representing the number of pixels, or a number along with an optional unit of measure appended (as a string).</desc>
+    </argument>
+  </signature>
+  <signature>
+    <added>1.8.0</added>
+    <argument name="function(index, height)" type="Function">
+      <desc>A function returning the outer height to set. Receives the index position of the element in the set and the old outer height as arguments. Within the function, <code>this</code> refers to the current element in the set.</desc>
+    </argument>
+  </signature>
+  <desc>Set the CSS outer Height of each element in the set of matched elements.</desc>
+  <longdesc>
+    <p>When calling <code>.outerHeight(value)</code>, the value can be either a string (number and unit) or a number. If only a number is provided for the value, jQuery assumes a pixel unit. If a string is provided, however, any valid CSS measurement may be used (such as <code>100px</code>, <code>50%</code>, or <code>auto</code>).</p>
+  </longdesc>
+
+  <example>
+    <desc>Change the outer height of each div the first time it is clicked (and change its color).</desc>
+    <code><![CDATA[
+var modHeight = 60;
+$( "div" ).one( "click", function() {
+  $( this ).outerHeight( modHeight ).addClass( "mod" );
+  modHeight -= 8;
+});
+]]></code>
+    <css><![CDATA[
+  div {
+    width: 50px;
+    padding: 10px;
+    height: 60px;
+    float: left;
+    margin: 5px;
+    background: red;
+    cursor: pointer;
+  }
+  .mod {
+    background: blue;
+    cursor: default;
+  }
+]]></css>
+    <html><![CDATA[
+<div>d</div>
+<div>d</div>
+<div>d</div>
+<div>d</div>
+<div>d</div>
+]]></html>
+  </example>
+
+  <category slug="css"/>
+  <category slug="dimensions"/>
+  <category slug="manipulation/style-properties"/>
+  <category slug="version/1.8"/>
+</entry>
+</entries>


### PR DESCRIPTION
Adds 2 new signatures to the `outerHeight` entry, see https://github.com/jquery/api.jquery.com/issues/98. Doesn't fix that issue yet since `outerWidth` needs to get done too.

@dmethvin This is nearly the same commit as https://github.com/jquery/api.jquery.com/commit/0051b225f73aae7b719afa2b8d2da2363a0c4082. Would you mind reviewing this?