### PR TITLE
child-selector: remove sentence about browser support

### DIFF
--- a/entries/child-selector.xml
+++ b/entries/child-selector.xml
@@ -13,7 +13,6 @@
   </signature>
   <desc>Selects all direct child elements specified by "child" of elements specified by "parent".</desc>
   <longdesc>
-    <p>As a CSS selector, the child combinator is supported by all modern web browsers including Safari, Firefox, Opera, Chrome, and Internet Explorer 7 and above, but notably not by Internet Explorer versions 6 and below. However, in jQuery, this selector (along with all others) works across all supported browsers, including IE6.</p>
     <p>The child combinator (E <strong>&gt;</strong> F) can be thought of as a more specific form of the descendant combinator (E F) in that it selects only first-level descendants.</p>
   </longdesc>
   <example>


### PR DESCRIPTION
Another PR for the `v3.0.0-docs` branch. Removed a sentence about on browser support in the `child-selector` post. It was mentioning an exception for IE6/7 so not needed anymore.