### PR TITLE
html: warn about using `.html()` to insert scripts

### DIFF
--- a/entries/html.xml
+++ b/entries/html.xml
@@ -119,6 +119,7 @@ $( "div.demo-container" ).html(function() {
       </code></pre>
       <p>Given a document with six paragraphs, this example will set the HTML of <code>&lt;div class="demo-container"&gt;</code> to <code>&lt;p&gt;All new content for &lt;em&gt;6 paragraphs!&lt;/em&gt;&lt;/p&gt;</code>.</p>
       <p>This method uses the browser's <code>innerHTML</code> property. Some browsers may not generate a DOM that exactly replicates the HTML source provided. For example, Internet Explorer prior to version 8 will convert all <code>href</code> properties on links to absolute URLs, and Internet Explorer prior to version 9 will not correctly handle HTML5 elements without the addition of a separate <a href="http://code.google.com/p/html5shiv/">compatibility layer</a>.</p>
+      <p>To set the content of a <code>&lt;script&gt;</code> element, which does not contain HTML, use the <a href="/text"><code>.text()</code></a> method and not <code>.html()</code>.</p>
       <p><strong>Note:</strong> In Internet Explorer up to and including version 9, setting the text content of an HTML element may corrupt the text nodes of its children that are being removed from the document as a result of the operation. If you are keeping references to these DOM elements and need them to be unchanged, use <code>.empty().html( string )</code> instead of <code>.html(string)</code> so that the elements are removed from the document before the new string is assigned to the element.</p>
     </longdesc>
     <example>


### PR DESCRIPTION
Would fix gh-618