### PR TITLE
Ajax: Update deprecation notes about .success(), .error() and .complete()

### DIFF
--- a/entries/jQuery.ajax.xml
+++ b/entries/jQuery.ajax.xml
@@ -19,7 +19,7 @@
         <desc>The content type sent in the request header that tells the server what kind of response it will accept in return.</desc>
       </property>
       <property default="true" name="async" type="Boolean">
-        <desc>By default, all requests are sent asynchronously (i.e. this is set to <code>true</code> by default). If you need synchronous requests, set this option to <code>false</code>. Cross-domain requests and <code>dataType: "jsonp"</code> requests do not support synchronous operation. Note that synchronous requests may temporarily lock the browser, disabling any actions while the request is active. <strong>As of jQuery 1.8, the use of <code>async: false</code> with jqXHR (<code>$.Deferred</code>) is deprecated; you must use the success/error/complete callback options instead of the corresponding methods of the jqXHR object such as <code>jqXHR.done()</code> or the deprecated <code>jqXHR.success()</code>.</strong></desc>
+        <desc>By default, all requests are sent asynchronously (i.e. this is set to <code>true</code> by default). If you need synchronous requests, set this option to <code>false</code>. Cross-domain requests and <code>dataType: "jsonp"</code> requests do not support synchronous operation. Note that synchronous requests may temporarily lock the browser, disabling any actions while the request is active. <strong>As of jQuery 1.8, the use of <code>async: false</code> with jqXHR (<code>$.Deferred</code>) is deprecated; you must use the success/error/complete callback options instead of the corresponding methods of the jqXHR object such as <code>jqXHR.done()</code></desc>
       </property>
       <property name="beforeSend" type="Function">
         <argument name="jqXHR" type="jqXHR"/>
@@ -200,7 +200,7 @@ $.ajax({
     <ul>
       <li>
         <strong>jqXHR.done(function( data, textStatus, jqXHR ) {});</strong>
-        <p>An alternative construct to the success callback option, the <code>.done()</code> method replaces the deprecated <code>jqXHR.success()</code> method. Refer to <code><a href="/deferred.done/">deferred.done()</a></code> for implementation details.</p>
+        <p>An alternative construct to the success callback option, refer to <code><a href="/deferred.done/">deferred.done()</a></code> for implementation details.</p>
       </li>
       <li>
         <strong>jqXHR.fail(function( jqXHR, textStatus, errorThrown ) {});</strong>
@@ -219,7 +219,7 @@ $.ajax({
       </li>
     </ul>
     <div class="warning">
-      <p><strong>Deprecation Notice:</strong> The <code>jqXHR.success()</code>, <code>jqXHR.error()</code>, and <code>jqXHR.complete()</code> callbacks are deprecated as of jQuery 1.8. To prepare your code for their eventual removal, use <code>jqXHR.done()</code>, <code>jqXHR.fail()</code>, and <code>jqXHR.always()</code> instead.</p>
+      <p><strong>Deprecation Notice:</strong> The <code>jqXHR.success()</code>, <code>jqXHR.error()</code>, and <code>jqXHR.complete()</code> callbacks are removed as of jQuery 3.0. You can use <code>jqXHR.done()</code>, <code>jqXHR.fail()</code>, and <code>jqXHR.always()</code> instead.</p>
     </div>
     <pre><code>
 // Assign handlers immediately after making the request,

--- a/entries/jQuery.get.xml
+++ b/entries/jQuery.get.xml
@@ -75,7 +75,7 @@ jqxhr.always(function() {
 });
     </code></pre>
     <h4>Deprecation Notice</h4>
-    <p>The <code>jqXHR.success()</code>, <code>jqXHR.error()</code>, and <code>jqXHR.complete()</code> callback methods introduced in jQuery 1.5 are <strong>deprecated as of jQuery 1.8</strong>. To prepare your code for their eventual removal, use <code>jqXHR.done()</code>, <code>jqXHR.fail()</code>, and <code>jqXHR.always()</code> instead.</p>
+    <p>The <code>jqXHR.success()</code>, <code>jqXHR.error()</code>, and <code>jqXHR.complete()</code> callback methods are <strong>removed as of jQuery 3.0</strong>. You can use <code>jqXHR.done()</code>, <code>jqXHR.fail()</code>, and <code>jqXHR.always()</code> instead.</p>
   </longdesc>
   <note id="same-origin-policy" type="additional"/>
   <note id="use-ajaxerror" type="additional" data-title="jQuery.get()"/>

--- a/entries/jQuery.getJSON.xml
+++ b/entries/jQuery.getJSON.xml
@@ -87,7 +87,7 @@ jqxhr.complete(function() {
 });
     </code></pre>
     <h4>Deprecation Notice</h4>
-    <p>The <code>jqXHR.success()</code>, <code>jqXHR.error()</code>, and <code>jqXHR.complete()</code> callback methods introduced in jQuery 1.5 are <strong>deprecated as of jQuery 1.8</strong>. To prepare your code for their eventual removal, use <code>jqXHR.done()</code>, <code>jqXHR.fail()</code>, and <code>jqXHR.always()</code> instead.</p>
+    <p>The <code>jqXHR.success()</code>, <code>jqXHR.error()</code>, and <code>jqXHR.complete()</code> callback methods are <strong>removed as of jQuery 3.0</strong>. You can use <code>jqXHR.done()</code>, <code>jqXHR.fail()</code>, and <code>jqXHR.always()</code> instead.</p>
   </longdesc>
   <note id="same-origin-policy" type="additional"/>
   <note id="same-origin-policy-exceptions" type="additional"/>

--- a/entries/jQuery.post.xml
+++ b/entries/jQuery.post.xml
@@ -77,7 +77,7 @@ jqxhr.always(function() {
     </code></pre>
 
     <h4>Deprecation Notice</h4>
-    <p>The <code>jqXHR.success()</code>, <code>jqXHR.error()</code>, and <code>jqXHR.complete()</code> callback methods introduced in jQuery 1.5 are <strong>deprecated as of jQuery 1.8</strong>. To prepare your code for their eventual removal, use <code>jqXHR.done()</code>, <code>jqXHR.fail()</code>, and <code>jqXHR.always()</code> instead.</p>
+    <p>The <code>jqXHR.success()</code>, <code>jqXHR.error()</code>, and <code>jqXHR.complete()</code> callback methods are <strong>removed as of jQuery 3.0</strong>. You can use <code>jqXHR.done()</code>, <code>jqXHR.fail()</code>, and <code>jqXHR.always()</code> instead.</p>
   </longdesc>
   <note id="same-origin-policy" type="additional"/>
   <note id="use-ajaxerror" type="additional" data-title="jQuery.post()"/>


### PR DESCRIPTION
PR for the v3 branch. Would fix #650.