### PR TITLE
jQuery.when(), deferred.promise(): remove unnecessary `new` operator

### DIFF
--- a/entries/deferred.promise.xml
+++ b/entries/deferred.promise.xml
@@ -18,7 +18,7 @@
     <desc>Create a Deferred and set two timer-based functions to either resolve or reject the Deferred after a random interval. Whichever one fires first "wins" and will call one of the callbacks. The second timeout has no effect since the Deferred is already complete (in a resolved or rejected state) from the first timeout action. Also set a timer-based progress notification function, and call a progress handler that adds "working..." to the document body.</desc>
     <code><![CDATA[
 function asyncEvent() {
-  var dfd = new jQuery.Deferred();
+  var dfd = jQuery.Deferred();
 
   // Resolve after a random interval
   setTimeout(function() {

--- a/entries/jQuery.when.xml
+++ b/entries/jQuery.when.xml
@@ -23,8 +23,8 @@ $.when( { testing: 123 } ).done(function( x ) {
     </code></pre>
     <p>In the case where multiple Deferred objects are passed to <code>jQuery.when()</code>, the method returns the Promise from a new "master" Deferred object that tracks the aggregate state of all the Deferreds it has been passed. The method will resolve its master Deferred as soon as all the Deferreds resolve, or reject the master Deferred as soon as one of the Deferreds is rejected. If the master Deferred is resolved, the doneCallbacks for the master Deferred are executed. The arguments passed to the doneCallbacks provide the resolved values for each of the Deferreds, and matches the order the Deferreds were passed to <code>jQuery.when()</code>. For example:</p>
     <pre><code>
-var d1 = new $.Deferred();
-var d2 = new $.Deferred();
+var d1 = $.Deferred();
+var d2 = $.Deferred();
 
 $.when( d1, d2 ).done(function ( v1, v2 ) {
     console.log( v1 ); // "Fish"
@@ -36,9 +36,9 @@ d2.resolve( "Pizza" );
     </code></pre>
     <p>In the event a Deferred was resolved with no value, the corresponding doneCallback argument will be undefined. If a Deferred resolved to a single value, the corresponding argument will hold that value. In the case where a Deferred resolved to multiple values, the corresponding argument will be an array of those values. For example:</p>
     <pre><code>
-var d1 = new $.Deferred();
-var d2 = new $.Deferred();
-var d3 = new $.Deferred();
+var d1 = $.Deferred();
+var d2 = $.Deferred();
+var d3 = $.Deferred();
 
 $.when( d1, d2, d3 ).done(function ( v1, v2, v3 ) {
     console.log( v1 ); // v1 is undefined


### PR DESCRIPTION
Make consistent with other docs. For example:
* [`done`](https://github.com/jquery/api.jquery.com/blob/03fcbfbd17b494cc1122b6727adfcd8101b0ea9b/entries/deferred.done.xml#L44)
* [`callbacks`](https://github.com/jquery/api.jquery.com/blob/03fcbfbd17b494cc1122b6727adfcd8101b0ea9b/entries/jQuery.Callbacks.xml#L250)