### PR TITLE
appendTo/prependTo: correct note about appending multiple elements

### DIFF
--- a/entries/appendTo.xml
+++ b/entries/appendTo.xml
@@ -53,7 +53,7 @@ $( "h2" ).appendTo( $( ".container" ) );
   &lt;h2&gt;Greetings&lt;/h2&gt;
 &lt;/div&gt;
     </code></pre>
-    <p>If there is more than one target element, however, cloned copies of the inserted element will be created for each target after the first, and that new set (the original element plus clones) is returned.</p>
+    <p>If there is more than one target element, however, cloned copies of the inserted element will be created for each target except the last, and that new set (the original element plus clones) is returned.</p>
 	<p><strong>Before jQuery 1.9,</strong> the append-to-single-element case did not create a new set, but instead returned the original set which made it difficult to use the <code>.end()</code> method reliably when being used with an unknown number of elements.</p>
   </longdesc>
   <note id="html-code-execution" type="additional"/>

--- a/entries/prependTo.xml
+++ b/entries/prependTo.xml
@@ -53,7 +53,7 @@ $( "h2" ).prependTo( $( ".container" ) );
   &lt;div class="inner"&gt;Goodbye&lt;/div&gt;
 &lt;/div&gt;
     </code></pre>
-    <p>If there is more than one target element, however, cloned copies of the inserted element will be created for each target after the first.</p>
+    <p>If there is more than one target element, however, cloned copies of the inserted element will be created for each target except the last.</p>
   </longdesc>
   <note id="html-code-execution" type="additional"/>
   <example>


### PR DESCRIPTION
This already happened for `appendTo` and `prependTo`, so this fixes gh-318.