### PR TITLE
triggerHandler: add signature for `.triggerHandler( event, extra )`

### DIFF
--- a/entries/triggerHandler.xml
+++ b/entries/triggerHandler.xml
@@ -13,6 +13,17 @@
       <desc>Additional parameters to pass along to the event handler.</desc>
     </argument>
   </signature>
+  <signature>
+    <added>1.3</added>
+    <argument name="event" type="Event">
+      <desc>A <a href="/category/events/event-object/"><code>jQuery.Event</code></a> object.</desc>
+    </argument>
+    <argument name="extraParameters" optional="true">
+      <type name="Array"/>
+      <type name="PlainObject"/>
+      <desc>Additional parameters to pass along to the event handler.</desc>
+    </argument>
+  </signature>
   <longdesc>
     <p><code>.triggerHandler( eventType )</code> executes all handlers bound with jQuery for the event type.  It will also execute any method called <code>on{eventType}()</code> found on the element.  The behavior of this method is similar to <a href="/trigger"><code>.trigger()</code></a>, with the following exceptions:</p>
     <ul>


### PR DESCRIPTION
Adds the `.triggerHandler( event, extraParameters )` signature to `.triggerHandler()`. Similar to the signature in the `.trigger()` entry.

Fixes https://github.com/jquery/api.jquery.com/issues/393.