### PR TITLE
fixed a small inconsistent xml attribute

### DIFF
--- a/entries/deferred.progress.xml
+++ b/entries/deferred.progress.xml
@@ -10,7 +10,7 @@
         A function, or array of functions, to be called when the Deferred generates progress notifications.
       </desc>
     </argument>
-    <argument name="progressCallbacks">
+    <argument name="progressCallbacks" optional="true">
       <type name="Function"/>
       <type name="Array"/>
       <desc>


### PR DESCRIPTION
In the deferred.progress.xml the second "argument" is not marked as optional

it is marked optional in all other entries ( deferred.always.xml:11 etc.)
 
