### PR TITLE
wrapAll: Updated return type of callback function

### DIFF
--- a/entries/wrapAll.xml
+++ b/entries/wrapAll.xml
@@ -14,9 +14,12 @@
   <signature>
     <added>1.4</added>
     <argument name="function" type="Function">
-      <desc>A function that returns a structure to wrap around the matched elements. Receives the index position of the element in the set as an argument. Within the function, <code>this</code> refers to the current element in the set.</desc>
+      <desc>A callback function returning the HTML content or jQuery object to wrap around the matched elements. Receives the index position of the element in the set as an argument. Within the function, <code>this</code> refers to the current element in the set.</desc>
       <argument name="index" type="Integer" />
-      <return type="String"/>
+      <return>
+        <type name="String"/>
+        <type name="jQuery"/>
+      </return>
     </argument>
   </signature>
   <desc>Wrap an HTML structure around all elements in the set of matched elements.</desc>


### PR DESCRIPTION
The return value of the the callback function can be a jQuery object as well. This is the same as `wrap()`