### PR TITLE
innerWidth: return type unified

### DIFF
--- a/entries/innerWidth.xml
+++ b/entries/innerWidth.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <entries>
   <desc>Get the current computed inner width (including padding but not border) for the first element in the set of matched elements or set the inner width of every matched element.</desc>
-<entry type="method" name="innerWidth" return="Integer">
+<entry type="method" name="innerWidth" return="Number">
   <title>.innerWidth()</title>
   <signature>
     <added>1.2.6</added>


### PR DESCRIPTION
all (width,height, outerWidth, outerHeight, innHeight) dimensions have a return type "Number" but innerWidth which has a return type "Integer".

I don't see the reason for that, so I guess this is a small mistake.

Eric,
