### PR TITLE
unwrap: add `selector` argument

### DIFF
--- a/entries/unwrap.xml
+++ b/entries/unwrap.xml
@@ -4,6 +4,12 @@
   <signature>
     <added>1.4</added>
   </signature>
+  <signature>
+    <added>3.0</added>
+    <argument name="selector" type="String" optional="true">
+      <desc>A selector to check the parent element against. If an element's parent does not match the selector, the element won't be unwrapped.</desc>
+    </argument>
+  </signature>
   <desc>Remove the parents of the set of matched elements from the DOM, leaving the matched elements in their place.</desc>
   <longdesc>
     <p>The <code>.unwrap()</code> method removes the element's parent. This is effectively the inverse of the <code><a href="/wrap/">.wrap()</a></code> method. The matched elements (and their siblings, if any) replace their parents within the DOM structure.</p>


### PR DESCRIPTION
PR for the v3 branch. Adds a `.unwrap(selector)` signature. Fixes https://github.com/jquery/api.jquery.com/issues/689.

Ref https://github.com/jquery/jquery/commit/7b09235ceed57bbcc26fc2c76147eb4e95ebdb92