### PR TITLE
Explain which key is META on common platforms

### DIFF
--- a/entries/event.metaKey.xml
+++ b/entries/event.metaKey.xml
@@ -8,6 +8,8 @@
   <longdesc>
     <p>Returns a boolean value (<code>true</code> or <code>false</code>) that indicates whether or not the <kbd>META</kbd> key was pressed at the time the event fired.
     This key might map to an alternative key name on some platforms.</p>
+    <p>On Macintosh keyboards, the <kbd>META</kbd> key maps to the <a href="http://en.wikipedia.org/wiki/Command_key">Command key (⌘)</a>.</p>
+    <p>On Windows keyboards, the <kbd>META</kbd> key maps to the <a href="http://en.wikipedia.org/wiki/Windows_key">Windows key</a>.</p>
   </longdesc>
   <example>
     <desc>Determine whether the META key was pressed when the event fired.</desc>


### PR DESCRIPTION
Since almost nobody has an [actual old-school Meta (◆) key](http://en.wikipedia.org/wiki/Meta_key) on their keyboard these days, let's save everyone the cross-referencing trip and explain what `metaKey` refers to in practice in the modern day.

Sources:
* https://w3c.github.io/uievents/#widl-KeyboardEvent-metaKey
* https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/metaKey