### PR TITLE
jQuery.uniqueSort: add new entry, deprecate `jQuery.unique()`

### DIFF
--- a/entries/jQuery.uniqueSort.xml
+++ b/entries/jQuery.uniqueSort.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
-<entry type="method" name="jQuery.unique" return="Array" deprecated="3.0">
-  <title>jQuery.unique()</title>
+<entry type="method" name="jQuery.uniqueSort" return="Array">
+  <title>jQuery.uniqueSort()</title>
   <signature>
-    <added>1.1.3</added>
+    <added>3.0</added>
     <argument name="array" type="Array">
       <desc>The Array of DOM elements.</desc>
     </argument>
   </signature>
   <desc>Sorts an array of DOM elements, in place, with the duplicates removed. Note that this only works on arrays of DOM elements, not strings or numbers.</desc>
   <longdesc>
-    <p><strong>As of jQuery 3.0, this method is deprecated and just an alias of <code><a href="/jQuery.uniqueSort/">jQuery.uniqueSort()</a></code>. Please use that method instead.</strong></p>
-    <p>The <code>$.unique()</code> function searches through an array of objects, sorting the array, and removing any duplicate nodes. A node is considered a duplicate if it is the <em>exact same</em> node as one already in the array; two different nodes with identical attributes are not considered to be duplicates. This function only works on plain JavaScript arrays of DOM elements, and is chiefly used internally by jQuery. You probably will never need to use it.</p>
+    <p>The <code>$.uniqueSort()</code> function searches through an array of objects, sorting the array, and removing any duplicate nodes. A node is considered a duplicate if it is the <em>exact same</em> node as one already in the array; two different nodes with identical attributes are not considered to be duplicates. This function only works on plain JavaScript arrays of DOM elements, and is chiefly used internally by jQuery. You probably will never need to use it.</p>
+    <p>Prior to jQuery 3.0, this method was called <code><a href="/jQuery.unique/">jQuery.unique()</a></code>.</p>
     <p>As of jQuery 1.4 the results will always be returned in document order.</p>
   </longdesc>
   <example>
@@ -23,7 +23,7 @@ var divs = $( "div" ).get();
 divs = divs.concat( $( ".dup" ).get() );
 $( "div:eq(1)" ).text( "Pre-unique there are " + divs.length + " elements." );
 
-divs = jQuery.unique( divs );
+divs = jQuery.uniqueSort( divs );
 $( "div:eq(2)" ).text( "Post-unique there are " + divs.length + " elements." )
   .css( "color", "red" );
 ]]></code>
@@ -42,5 +42,4 @@ $( "div:eq(2)" ).text( "Post-unique there are " + divs.length + " elements." )
 ]]></html>
   </example>
   <category slug="utilities"/>
-  <category slug="version/1.1.3"/>
 </entry>


### PR DESCRIPTION
For the v3 branch. Fixes gh-731

Added a deprecation notice to the `jQuery.unique()` entry and added a new `jQuery.uniqueSort()` entry.