### PR TITLE
Clarified behavior of `:checked` selector. Turned text into link to `…

### DIFF
--- a/entries/checked-selector.xml
+++ b/entries/checked-selector.xml
@@ -71,40 +71,6 @@ $( "input" ).on( "click", function() {
 </form>
 ]]></html>
   </example>
-  <example>
-    <desc>Determine how many input elements are checked.</desc>
-    <code><![CDATA[
-var countCheckedOptions = function() {
-  var n = $( "option:checked" ).length;
-  $( "#log_option" ).text( n + (n === 1 ? " is" : " are") + " ':checked'!" );
-};
-countCheckedOptions();
-
-$( "select" ).on( "change", countCheckedOptions );
-]]></code>
-    <css><![CDATA[
-  #log_option {
-    color: red;
-  }
-]]></css>
-    <html><![CDATA[
-<form>
-  <label for="cities">Cities I'd like to visit</label>
-  <br />
-  <select name="cities" id="cities" size="8" multiple="multiple">
-    <option value="Athens">Athens</option>
-    <option value="Barcelona">Barcelona</option>
-    <option value="Chicago">Chicago</option>
-    <option value="Detroit">Detroit</option>
-    <option value="Frankfurt">Frankfurt</option>
-    <option value="London">London</option>
-    <option value="Madrid">Madrid</option>
-    <option value="Paris">Paris</option>
-  </select>
-</form>
-<div id="log_option"></div>
-]]></html>
-  </example>
   <category slug="selectors/form-selectors"/>
   <category slug="version/1.0"/>
 </entry>

--- a/entries/checked-selector.xml
+++ b/entries/checked-selector.xml
@@ -7,7 +7,8 @@
   </signature>
   <desc>Matches all elements that are checked or selected.</desc>
   <longdesc>
-    <p>The <code>:checked</code> selector works for checkboxes, radio buttons, and select elements. For select elements only, use the <code>:selected</code> selector.</p>
+    <p>The <code>:checked</code> selector works for checkboxes, radio buttons, and "selected" options of select elements.</p>
+    <p>To retrieve only the selected options of <code>select</code> elements, use the <a href="/selected-selector/"><code>:selected</code></a> selector.</p>
   </longdesc>
   <example>
     <desc>Determine how many input elements are checked.</desc>
@@ -68,6 +69,40 @@ $( "input" ).on( "click", function() {
   </div>
   <div id="log"></div>
 </form>
+]]></html>
+  </example>
+  <example>
+    <desc>Determine how many input elements are checked.</desc>
+    <code><![CDATA[
+var countCheckedOptions = function() {
+  var n = $( "option:checked" ).length;
+  $( "#log_option" ).text( n + (n === 1 ? " is" : " are") + " ':checked'!" );
+};
+countCheckedOptions();
+
+$( "select" ).on( "change", countCheckedOptions );
+]]></code>
+    <css><![CDATA[
+  #log_option {
+    color: red;
+  }
+]]></css>
+    <html><![CDATA[
+<form>
+  <label for="cities">Cities I'd like to visit</label>
+  <br />
+  <select name="cities" id="cities" size="8" multiple="multiple">
+    <option value="Athens">Athens</option>
+    <option value="Barcelona">Barcelona</option>
+    <option value="Chicago">Chicago</option>
+    <option value="Detroit">Detroit</option>
+    <option value="Frankfurt">Frankfurt</option>
+    <option value="London">London</option>
+    <option value="Madrid">Madrid</option>
+    <option value="Paris">Paris</option>
+  </select>
+</form>
+<div id="log_option"></div>
 ]]></html>
   </example>
   <category slug="selectors/form-selectors"/>

--- a/entries/checked-selector.xml
+++ b/entries/checked-selector.xml
@@ -7,7 +7,7 @@
   </signature>
   <desc>Matches all elements that are checked or selected.</desc>
   <longdesc>
-    <p>The <code>:checked</code> selector works for checkboxes, radio buttons, and "selected" options of select elements.</p>
+    <p>The <code>:checked</code> selector works for checkboxes, radio buttons, and options of <code>select</code> elements.</p>
     <p>To retrieve only the selected options of <code>select</code> elements, use the <a href="/selected-selector/"><code>:selected</code></a> selector.</p>
   </longdesc>
   <example>


### PR DESCRIPTION
…:selected` selector. Added example for how `:checked` selector works with `<option>` elements. Addresses https://github.com/jquery/api.jquery.com/issues/558

See [http://jsfiddle.net/jhfrench/n3w8y41p/](http://jsfiddle.net/jhfrench/n3w8y41p/) for a working demonstration of the new example.