### PR TITLE
Build: move redirects from the infrastucture repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "grunt": "0.4.5",
-    "grunt-jquery-content": "2.0.0"
+    "grunt-jquery-content": "2.3.0"
   }
 }

--- a/redirects.json
+++ b/redirects.json
@@ -1,0 +1,3 @@
+{
+	"/api/": "/resources/api.xml"
+}


### PR DESCRIPTION
Possible as of grunt-jquery-content 2.3.0, and now we want to port all redirects over from the nginx configs to the repos. cc @gnarf 

Ref https://github.com/jquery/infrastructure/blob/puppet-master/modules/jquery/manifests/wp/jquery.pp#L66. Apparently for this site there's only one redirect that needs to be moved.

