### PR TITLE
the type of argument can be an ArrayLikeObject

### DIFF
--- a/entries/jQuery.grep.xml
+++ b/entries/jQuery.grep.xml
@@ -4,7 +4,7 @@
   <desc>Finds the elements of an array which satisfy a filter function. The original array is not affected.</desc>
   <signature>
     <added>1.0</added>
-    <argument name="array" type="Array">
+    <argument name="array" type="ArrayLikeObject">
       <desc>The array to search through.</desc>
     </argument>
     <argument name="function" type="Function">


### PR DESCRIPTION
not only `array` can be accepted, but `ArrayLikeObject` too:

```javascript
var $selected = $('.selected');
$.grep($selected, function(e, i){return true;})
```