### PR TITLE
the type of argument can be an ArrayLikeObject

### DIFF
--- a/entries/jQuery.grep.xml
+++ b/entries/jQuery.grep.xml
@@ -4,7 +4,7 @@
   <desc>Finds the elements of an array which satisfy a filter function. The original array is not affected.</desc>
   <signature>
     <added>1.0</added>
-    <argument name="array" type="Array">
+    <argument name="array" type="ArrayLikeObject">
       <desc>The array to search through.</desc>
     </argument>
     <argument name="function" type="Function">

--- a/entries/jQuery.grep.xml
+++ b/entries/jQuery.grep.xml
@@ -5,7 +5,7 @@
   <signature>
     <added>1.0</added>
     <argument name="array" type="ArrayLikeObject">
-      <desc>The array to search through.</desc>
+      <desc>The array-like object to search through.</desc>
     </argument>
     <argument name="function" type="Function">
       <argument name="elementOfArray" type="Object" />


### PR DESCRIPTION
`grep`:
not only `array` can be accepted, but `ArrayLikeObject` too:

```javascript
var $selected = $('.selected');
$.grep($selected, function(e, i){return true;})
```

if you look at the implementation
https://github.com/jquery/jquery/blob/2.1-stable/src/core.js#L384
it should be fully supported.
like by merge:
https://github.com/jquery/jquery/blob/2.1-stable/src/core.js#L370