### PR TITLE
Moved noConflict call to below where $ is used. One line change.

### DIFF
--- a/entries/jQuery.noConflict.xml
+++ b/entries/jQuery.noConflict.xml
@@ -24,10 +24,10 @@ $.noConflict();
 &lt;script src="other_lib.js"&gt;&lt;/script&gt;
 &lt;script src="jquery.js"&gt;&lt;/script&gt;
 &lt;script&gt;
-$.noConflict();
 jQuery( document ).ready(function( $ ) {
   // Code that uses jQuery's $ can follow here.
 });
+$.noConflict();
 // Code that uses other library's $ can follow here.
 &lt;/script&gt;
     </code></pre>


### PR DESCRIPTION
As described in the issue I opened on this subject and in the git tag, it was a one line change. noConflict was called in a code snippet just before where $ was used. The noConflict line was moved down below the point where $ was used.
