### PR TITLE
index() returns an integer

### DIFF
--- a/entries/index.xml
+++ b/entries/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="index" return="Number">
+<entry type="method" name="index" return="Integer">
   <title>.index()</title>
   <signature>
     <added>1.4</added>


### PR DESCRIPTION
Just to be accurate ;)
The integer type is described in https://api.jquery.com/Types/#Integer.
Several methods/properties already use integer as return type. e.g. [length](https://api.jquery.com/length/)