### PR TITLE
attr: Document attr(key, null) to remove attribute

### DIFF
--- a/entries/attr.xml
+++ b/entries/attr.xml
@@ -147,7 +147,8 @@ The title of the emphasis is:<div></div>
       <argument name="value">
         <type name="String"/>
         <type name="Number"/>
-        <desc>A value to set for the attribute.</desc>
+        <type name="Null"/>
+        <desc>A value to set for the attribute. If <code>null</code>, the specified attribute will be removed (as in <a href="/removeAttr/">.removeAttr()</a>).</desc>
       </argument>
     </signature>
     <signature>

--- a/entries/attr.xml
+++ b/entries/attr.xml
@@ -148,7 +148,7 @@ The title of the emphasis is:<div></div>
         <type name="String"/>
         <type name="Number"/>
         <type name="Null"/>
-        <desc>A value to set for the attribute. If <code>null</code>, the specified attribute will be removed (as in <a href="/removeAttr/">.removeAttr()</a>).</desc>
+        <desc>A value to set for the attribute. If <code>null</code>, the specified attribute will be removed (as in <a href="/removeAttr/"><code>.removeAttr()</code></a>).</desc>
       </argument>
     </signature>
     <signature>

--- a/pages/Types.html
+++ b/pages/Types.html
@@ -433,7 +433,7 @@ x.splice( 1, 2 ) // [ 2, 3 ]
 </code></pre>
 
 <h2 id="Null">Null</h2>
-<p>The <code>null</code> keyword is a JavaScript literal that is commonly used to signal the absence of an intentional value.</p>
+<p>The <code>null</code> keyword is a JavaScript literal that is commonly used to express the absence of an intentional value.</p>
 
 <h2 id="Date"> Date </h2>
 <p>The Date type is a JavaScript object that represents a single moment in time. Date objects are instantiated using their constructor function, which by default creates an object that represents the current date and time.

--- a/pages/Types.html
+++ b/pages/Types.html
@@ -432,6 +432,9 @@ x.splice( 1, 2 ) // [ 2, 3 ]
   jQuery.isPlainObject( o ); // true
 </code></pre>
 
+<h2 id="Null">Null</h2>
+<p>The <code>null</code> keyword is a JavaScript literal that is commonly used to signal the absence of an intentional value.</p>
+
 <h2 id="Date"> Date </h2>
 <p>The Date type is a JavaScript object that represents a single moment in time. Date objects are instantiated using their constructor function, which by default creates an object that represents the current date and time.
 </p>


### PR DESCRIPTION
In addition, introduce the `null` value type to more completely describe
the `attr` method's signature.

jQuery implements explicit support for this behavior [1]:

    if ( value === null ) {
      jQuery.removeAttr( elem, name );
      return;
    }

and also maintains unit tests to verify it [2]:

    jQuery( "#name" ).attr( "name", null );
    assert.equal( jQuery( "#name" ).attr( "name" ), undefined, "Remove name attribute" );

Fixes gh-523

[1] https://github.com/jquery/jquery/blob/1823a715660a5f31dd7e05672e9ad020066256a9/src/attributes/attr.js#L55-L58
[2] https://github.com/jquery/jquery/blob/1823a715660a5f31dd7e05672e9ad020066256a9/test/unit/attributes.js#L283-L284