### PR TITLE
Indicate where data will be passed in $.one doc

### DIFF
--- a/entries/one.xml
+++ b/entries/one.xml
@@ -8,7 +8,7 @@
       <desc>A string containing one or more JavaScript event types, such as "click" or "submit," or custom event names.</desc>
     </argument>
     <argument name="data" type="PlainObject" optional="true">
-      <desc>An object containing data that will be passed to the event handler.</desc>
+      <desc>Data to be passed to the handler in <a href="/event.data/"><code>event.data</code></a> when an event is triggered.</desc>
     </argument>
     <argument name="handler" type="Function">
       <desc>A function to execute at the time the event is triggered.</desc>


### PR DESCRIPTION
I only found the `data` after inspecting `event` further. This change will make it clearer where to get `data` (and consistent with the docs for `.one( events [, selector ] [, data ], handler )` and `.one( events [, selector ] [, data ] )`).

If people think it would be great to make this change for other jquery fns too, the following fns still use the old desc:

```
entries/bind.xml
entries/blur.xml
entries/change.xml
entries/click.xml
entries/contextmenu.xml
entries/dblclick.xml
entries/delegate.xml
entries/error.xml
entries/focus.xml
entries/focusin.xml
entries/focusout.xml
entries/keydown.xml
entries/keypress.xml
entries/keyup.xml
entries/live.xml
entries/load-event.xml
entries/mousedown.xml
entries/mouseenter.xml
entries/mouseleave.xml
entries/mousemove.xml
entries/mouseout.xml
entries/mouseover.xml
entries/mouseup.xml
entries/resize.xml
entries/scroll.xml
entries/select.xml
entries/submit.xml
```

I'd be happy to make changes as part of this PR
