### PR TITLE
Manipulation: fix after/before xml parsing

### DIFF
--- a/entries/after.xml
+++ b/entries/after.xml
@@ -30,9 +30,9 @@
       </return>
     </argument>
   </signature>
-   <signature>
+  <signature>
     <added>1.10</added>
-    <argument name="function" type="Function">
+    <argument name="function-html" type="Function">
       <desc>A function that returns an HTML string, DOM element(s), or jQuery object to insert after each element in the set of matched elements. Receives the index position of the element in the set and the old HTML value of the element as arguments. Within the function, <code>this</code> refers to the current element in the set.</desc>
       <argument name="index" type="Integer" />
       <argument name="html" type="String" />

--- a/entries/before.xml
+++ b/entries/before.xml
@@ -33,7 +33,7 @@
   </signature>
    <signature>
     <added>1.10</added>
-    <argument name="function" type="Function">
+    <argument name="function-html" type="Function">
       <argument name="index" type="Integer" />
       <argument name="html" type="String" />
       <return>


### PR DESCRIPTION
I ran `grunt deploy` locally and ran into this error. Not sure why it's not happening in CI testing. This update seems to fix it.