### PR TITLE
Link to W3C for unquoted single word

### DIFF
--- a/entries/attribute-contains-prefix-selector.xml
+++ b/entries/attribute-contains-prefix-selector.xml
@@ -8,7 +8,7 @@
       <desc>An attribute name.</desc>
     </argument>
     <argument name="value" type="String">
-      <desc>An attribute value. Can be either an unquoted single word or a quoted string.</desc>
+      <desc>An attribute value. Can be either an <a href="https://www.w3.org/TR/css3-selectors/#attribute-selectors">unquoted single word</a> or a quoted string.</desc>
     </argument>
   </signature>
   <desc>Selects elements that have the specified attribute with a value either equal to a given string or starting with that string followed by a hyphen (-).</desc>

--- a/entries/attribute-contains-selector.xml
+++ b/entries/attribute-contains-selector.xml
@@ -8,7 +8,7 @@
       <desc>An attribute name.</desc>
     </argument>
     <argument name="value" type="String">
-      <desc>An attribute value. Can be either an unquoted single word or a quoted string.</desc>
+      <desc>An attribute value. Can be either an <a href="https://www.w3.org/TR/css3-selectors/#attribute-selectors">unquoted single word</a> or a quoted string.</desc>
     </argument>
   </signature>
   <desc>Selects elements that have the specified attribute with a value containing a given substring.</desc>

--- a/entries/attribute-contains-word-selector.xml
+++ b/entries/attribute-contains-word-selector.xml
@@ -8,7 +8,7 @@
       <desc>An attribute name.</desc>
     </argument>
     <argument name="value" type="String">
-      <desc>An attribute value. Can be either an unquoted single word or a quoted string.</desc>
+      <desc>An attribute value. Can be either an <a href="https://www.w3.org/TR/css3-selectors/#attribute-selectors">unquoted single word</a> or a quoted string.</desc>
     </argument>
   </signature>
   <desc>Selects elements that have the specified attribute with a value containing a given word, delimited by spaces.</desc>

--- a/entries/attribute-ends-with-selector.xml
+++ b/entries/attribute-ends-with-selector.xml
@@ -8,7 +8,7 @@
       <desc>An attribute name.</desc>
     </argument>
     <argument name="value" type="String">
-      <desc>An attribute value. Can be either an unquoted single word or a quoted string.</desc>
+      <desc>An attribute value. Can be either an <a href="https://www.w3.org/TR/css3-selectors/#attribute-selectors">unquoted single word</a> or a quoted string.</desc>
     </argument>
   </signature>
   <desc>Selects elements that have the specified attribute with a value ending exactly with a given string. The comparison is case sensitive.</desc>

--- a/entries/attribute-equals-selector.xml
+++ b/entries/attribute-equals-selector.xml
@@ -8,7 +8,7 @@
       <desc>An attribute name.</desc>
     </argument>
     <argument name="value" type="String">
-      <desc>An attribute value. <strong>Can be either an unquoted single word or a quoted string.</strong></desc>
+      <desc>An attribute value. <strong>Can be either an <a href="https://www.w3.org/TR/css3-selectors/#attribute-selectors">unquoted single word</a> or a quoted string.</strong></desc>
     </argument>
   </signature>
   <desc>Selects elements that have the specified attribute with a value exactly equal to a certain value.</desc>

--- a/entries/attribute-not-equal-selector.xml
+++ b/entries/attribute-not-equal-selector.xml
@@ -8,7 +8,7 @@
       <desc>An attribute name.</desc>
     </argument>
     <argument name="value" type="String">
-      <desc>An attribute value. Can be either an unquoted single word or a quoted string.</desc>
+      <desc>An attribute value. Can be either an <a href="https://www.w3.org/TR/css3-selectors/#attribute-selectors">unquoted single word</a> or a quoted string.</desc>
     </argument>
   </signature>
   <desc>Select elements that either don't have the specified attribute, or do have the specified attribute but not with a certain value.</desc>

--- a/entries/attribute-starts-with-selector.xml
+++ b/entries/attribute-starts-with-selector.xml
@@ -8,7 +8,7 @@
       <desc>An attribute name.</desc>
     </argument>
     <argument name="value" type="String">
-      <desc>An attribute value. Can be either an unquoted single word or a quoted string.</desc>
+      <desc>An attribute value. Can be either an <a href="https://www.w3.org/TR/css3-selectors/#attribute-selectors">unquoted single word</a> or a quoted string.</desc>
     </argument>
   </signature>
   <desc>Selects elements that have the specified attribute with a value beginning exactly with a given string.</desc>


### PR DESCRIPTION
Unquoted single word has a specific definition in this case that is not
succinct. A link to the spec helps developers understand what is meant.

fixes gh-910
ref jquery/jquery#2824