### PR TITLE
Fixing documentation for the :disabled selector

### DIFF
--- a/entries/disabled-selector.xml
+++ b/entries/disabled-selector.xml
@@ -9,7 +9,9 @@
   <longdesc>
     <p>As with other pseudo-class selectors (those that begin with a ":"), it is recommended to precede it with a tag name or some other selector; otherwise, the universal selector ("*") is implied. In other words, the bare <code>$(':disabled')</code> is equivalent to <code>$('*:disabled')</code>, so <code>$('input:disabled')</code> or similar should be used instead. </p>
 
-    <p>Although their resulting selections are usually the same, the <code>:disabled</code> selector is subtly different from the <code>[disabled]</code> attribute selector; <code>:disabled</code> checks the boolean (true/false) value of the element's disabled property while <code>[disabled]</code> checks for the existence of the disabled attribute.</p>
+    <p>Although their resulting selections are usually the same, the <code>:disabled</code> selector is subtly different from the <code>[disabled]</code> attribute selector;
+      <code>:disabled</code> matches elements that are <a href="https://html.spec.whatwg.org/multipage/scripting.html#disabled-elements" target="_blank">actually disabled</a>
+      while <code>[disabled]</code> only checks for the existence of the disabled attribute.</p>
 
     <p>The <code>:disabled</code> selector should only be used for selecting HTML elements that support the <code>disabled</code> attribute (<code>&lt;button&gt;</code>, <code>&lt;input&gt;</code>, <code>&lt;optgroup&gt;</code>, <code>&lt;option&gt;</code>, <code>&lt;select&gt;</code>, and <code>&lt;textarea&gt;</code>).</p>
 

--- a/entries/disabled-selector.xml
+++ b/entries/disabled-selector.xml
@@ -13,7 +13,7 @@
       <code>:disabled</code> matches elements that are <a href="https://html.spec.whatwg.org/multipage/scripting.html#disabled-elements" target="_blank">actually disabled</a>
       while <code>[disabled]</code> only checks for the existence of the disabled attribute.</p>
 
-    <p>The <code>:disabled</code> selector should only be used for selecting HTML elements that support the <code>disabled</code> attribute (<code>&lt;button&gt;</code>, <code>&lt;input&gt;</code>, <code>&lt;optgroup&gt;</code>, <code>&lt;option&gt;</code>, <code>&lt;select&gt;</code>, and <code>&lt;textarea&gt;</code>).</p>
+    <p>The <code>:disabled</code> selector should only be used for selecting HTML elements that support the <code>disabled</code> attribute (<code>&lt;button&gt;</code>, <code>&lt;input&gt;</code>, <code>&lt;optgroup&gt;</code>, <code>&lt;option&gt;</code>, <code>&lt;select&gt;</code>, <code>&lt;textarea&gt;</code>, <code>&lt;menuitem&gt;</code>, and <code>&lt;fieldset&gt;</code>).</p>
 
   </longdesc>
   <example>

--- a/entries/disabled-selector.xml
+++ b/entries/disabled-selector.xml
@@ -9,9 +9,7 @@
   <longdesc>
     <p>As with other pseudo-class selectors (those that begin with a ":"), it is recommended to precede it with a tag name or some other selector; otherwise, the universal selector ("*") is implied. In other words, the bare <code>$(':disabled')</code> is equivalent to <code>$('*:disabled')</code>, so <code>$('input:disabled')</code> or similar should be used instead. </p>
 
-    <p>Although their resulting selections are usually the same, the <code>:disabled</code> selector is subtly different from the <code>[disabled]</code> attribute selector;
-      <code>:disabled</code> matches elements that are <a href="https://html.spec.whatwg.org/multipage/scripting.html#disabled-elements" target="_blank">actually disabled</a>
-      while <code>[disabled]</code> only checks for the existence of the disabled attribute.</p>
+    <p>Although their resulting selections are usually the same, the <code>:disabled</code> selector is subtly different from the <code>[disabled]</code> attribute selector;<code>:disabled</code> matches elements that are <a href="https://html.spec.whatwg.org/multipage/scripting.html#disabled-elements">actually disabled</a> while <code>[disabled]</code> only checks for the existence of the disabled attribute.</p>
 
     <p>The <code>:disabled</code> selector should only be used for selecting HTML elements that support the <code>disabled</code> attribute (<code>&lt;button&gt;</code>, <code>&lt;input&gt;</code>, <code>&lt;optgroup&gt;</code>, <code>&lt;option&gt;</code>, <code>&lt;select&gt;</code>, <code>&lt;textarea&gt;</code>, <code>&lt;menuitem&gt;</code>, and <code>&lt;fieldset&gt;</code>).</p>
 


### PR DESCRIPTION
Hey guys @AurelioDeRosa @gibson042 

I just quickly updated the documentation for the disabled selector based on [issue #734](https://github.com/jquery/api.jquery.com/issues/734).

I've included a link to the html spec page to define exactly what a disabled element is and added in the `menuitem` and `fieldset` to the list of html elements that support the disabled attribute.