### PR TITLE
Clarifying purpose of one()

### DIFF
--- a/entries/one.xml
+++ b/entries/one.xml
@@ -44,7 +44,7 @@
     </argument>
   </signature>
   <longdesc>
-    <p>The  <code>.one()</code> method is identical to  <code>.on()</code>, except that the handler is unbound after its first invocation. For example:</p>
+    <p>The  <code>.one()</code> method is identical to  <code>.on()</code>, except that the handler for a given element and event type is unbound after its first invocation. For example:</p>
     <pre><code>
 $( "#foo" ).one( "click", function() {
   alert( "This will be displayed only once." );

--- a/entries/one.xml
+++ b/entries/one.xml
@@ -61,7 +61,7 @@ $( "#foo" ).on( "click", function( event ) {
     <p>If the first argument contains more than one space-separated event types, the event handler is called <em>once for each event type</em>.</p>
     <pre><code>
 $( "#foo" ).one( "click mouseover", function() {
-  alert( "This could be displayed twice." );
+  alert( "The " + event.type + " event happened!" );
 });
     </code></pre>
     <p>In the example above the alert could be displayed twice due to the <em>two</em> event types (<code>click</code> and <code>mouseover</code>).</p>

--- a/entries/one.xml
+++ b/entries/one.xml
@@ -59,6 +59,12 @@ $( "#foo" ).on( "click", function( event ) {
     </code></pre>
     <p>In other words, explicitly calling <code>.off()</code> from within a regularly-bound handler has exactly the same effect.</p>
     <p>If the first argument contains more than one space-separated event types, the event handler is called <em>once for each event type</em>.</p>
+    <pre><code>
+$( "#foo" ).one( "click mouseover", function() {
+  alert( "This could be displayed twice." );
+});
+    </code></pre>
+    <p>In the example above the alert could be displayed twice due to the <i>two</i> event types (<code>click</code> and <code>mouseover</code>).</p>
   </longdesc>
   <example>
     <desc>Tie a one-time click to each div.</desc>

--- a/entries/one.xml
+++ b/entries/one.xml
@@ -64,7 +64,7 @@ $( "#foo" ).one( "click mouseover", function() {
   alert( "This could be displayed twice." );
 });
     </code></pre>
-    <p>In the example above the alert could be displayed twice due to the <i>two</i> event types (<code>click</code> and <code>mouseover</code>).</p>
+    <p>In the example above the alert could be displayed twice due to the <em>two</em> event types (<code>click</code> and <code>mouseover</code>).</p>
   </longdesc>
   <example>
     <desc>Tie a one-time click to each div.</desc>


### PR DESCRIPTION
Hey @AurelioDeRosa 

Regarding [issue #796](https://github.com/jquery/api.jquery.com/issues/796) I have changed the wording slightly and added in a code example using multiple event types to show that the handler can be called once for each event type.