### PR TITLE
Updated 'beforeunload' wording

### DIFF
--- a/entries/unload.xml
+++ b/entries/unload.xml
@@ -23,7 +23,7 @@
     <p>This method is a shortcut for <code>.on( "unload", handler )</code>.</p>
     <p>The <code>unload</code> event is sent to the <code>window</code> element when the user navigates away from the page. This could mean one of many things. The user could have clicked on a link to leave the page, or typed in a new URL in the address bar. The forward and back buttons will trigger the event. Closing the browser window will cause the event to be triggered. Even a page reload will first create an <code>unload</code> event.</p>
     <div class="warning">
-      <p>The exact handling of the <code>unload</code> event has varied from version to version of browsers. For example, some versions of Firefox trigger the event when a link is followed, but not when the window is closed. In practical usage, behavior should be tested on all supported browsers, and contrasted with the proprietary <code>beforeunload</code> event.</p>
+      <p>The exact handling of the <code>unload</code> event has varied from version to version of browsers. For example, some versions of Firefox trigger the event when a link is followed, but not when the window is closed. In practical usage, behavior should be tested on all supported browsers and contrasted with the similar <code>beforeunload</code> event.</p>
     </div>
     <p>Any <code>unload</code> event handler should be bound to the <code>window</code> object:</p>
     <pre><code>


### PR DESCRIPTION
Hey guys @AurelioDeRosa @agcolom 

I've just made a tiny change here to update the wording to not use 'proprietary' and instead use 'similar'.

Fixes [issue #364](https://github.com/jquery/api.jquery.com/issues/364)