### PR TITLE
Explicit that .progress can take more than 2 arguments

### DIFF
--- a/entries/deferred.progress.xml
+++ b/entries/deferred.progress.xml
@@ -14,7 +14,7 @@
       <type name="Function"/>
       <type name="Array"/>
       <desc>
-        Optional additional function, or array of functions, to be called when the Deferred generates progress notifications.
+        Optional additional functions, or arrays of functions, to be called when the Deferred generates progress notifications.
       </desc>
     </argument>
   </signature>


### PR DESCRIPTION
More conform with the .fail and .done doc