### PR TITLE
jQuery.parseJSON: Move the deprecation note to the top, rephrase it

### DIFF
--- a/entries/jQuery.parseJSON.xml
+++ b/entries/jQuery.parseJSON.xml
@@ -14,6 +14,7 @@
   </signature>
   <desc>Takes a well-formed JSON string and returns the resulting JavaScript value.</desc>
   <longdesc>
+    <p>As of jQuery 3.0, <code>$.parseJSON</code> is deprecated. To parse JSON strings use the native <code>JSON.parse</code> method instead.</p>
     <p>Passing in a malformed JSON string results in a JavaScript exception being thrown. For example, the following are all invalid JSON strings:</p>
     <ul>
       <li><code>"{test: 1}"</code> (test does not have double quotes around it).</li>
@@ -26,7 +27,6 @@
     <p>The JSON standard does not permit "control characters" such as a tab or newline. An example like <code>$.parseJSON( '{ "testing":"1\t2\n3" }' )</code> will throw an error in most implementations because the JavaScript parser converts the string's tab and newline escapes into literal tab and newline; doubling the backslashes like <code>"1\\t2\\n3"</code> yields expected results. This problem is often seen when injecting JSON into a JavaScript file from a server-side language such as PHP.</p>
     <p>Where the browser provides a native implementation of <code>JSON.parse</code>, jQuery uses it to parse the string. For details on the JSON format, see <a href="http://json.org/">http://json.org/</a>.</p>
     <p>Prior to jQuery 1.9, <code>$.parseJSON</code> returned <code>null</code> instead of throwing an error if it was passed an empty string, <code>null</code>, or <code>undefined</code>, even though those are not valid JSON.</p>
-    <p>As of jQuery 3.0, <code>$.parseJSON</code> is deprecated. To parse JSON objects, use the native <code>JSON.parse</code> method instead.</p>
   </longdesc>
   <example>
     <desc>Parse a JSON string.</desc>


### PR DESCRIPTION
The deprecation note has been moved to the top of the description as it's the
most important information about the API. This is also how other pages for
deprecated APIs are documented.

Also, the message has been rephrased a little as JSON is a string, not an
object.

Ref #899