### PR TITLE
serializeArray: Document Behavior for Value-less Input Elements

### DIFF
--- a/entries/serializeArray.xml
+++ b/entries/serializeArray.xml
@@ -28,7 +28,7 @@
   &lt;/div&gt;
 &lt;/form&gt;
     </code></pre>
-    <p>The <code>.serializeArray()</code> method uses the standard W3C rules for <a href="http://www.w3.org/TR/html401/interact/forms.html#h-17.13.2">successful controls</a> to determine which elements it should include; in particular the element cannot be disabled and must contain a <code>name</code> attribute. No submit button value is serialized since the form was not submitted using a button. Data from file select elements is not serialized.</p>
+    <p>The <code>.serializeArray()</code> method uses the standard W3C rules for <a href="http://www.w3.org/TR/html401/interact/forms.html#h-17.13.2">successful controls</a> to determine which elements it should include; in particular the element cannot be disabled and must contain a <code>name</code> attribute. No submit button value is serialized since the form was not submitted using a button. Data from file select elements is not serialized. Elements that do not contain a <code>value</code> attribute are represented with the empty string value.</p>
     <p>This method can act on a jQuery object that has selected individual form controls, such as <code>&lt;input&gt;</code>, <code>&lt;textarea&gt;</code>, and <code>&lt;select&gt;</code>. However, it is typically easier to select the <code>&lt;form&gt;</code> element itself for serialization:</p>
     <pre><code>
 $( "form" ).submit(function( event ) {


### PR DESCRIPTION
Formally define jQuery's behavior when `<input>` elements which specify a
`name` property but no corresponding `value`. This behavior should be considered
stable because it is implicitly asserted in jQuery's unit test suite through
tests for the `serialize` method [1].

[1] https://github.com/jquery/jquery/blob/efdb8a46e4213dcf69f792c42c234c6b112ba471/test/unit/serialize.js#L125-L127

The expected behavior here is a little ambiguous because it could also be valid to simply skip such elements in the serialization process. That is [the Cheerio project](https://github.com/cheeriojs/cheerio/)'s current behavior, but before [altering it to match jQuery's current behavior](https://github.com/cheeriojs/cheerio/pull/842), I'd like to make the behavior explicit.