### PR TITLE
jQuery.when: Add Thenable and Promise as acceptable types

### DIFF
--- a/entries/jQuery.when.xml
+++ b/entries/jQuery.when.xml
@@ -3,11 +3,14 @@
   <title>jQuery.when()</title>
   <signature>
     <added>1.5</added>
-    <argument name="deferreds" type="Deferred">
-      <desc>Zero or more Deferred objects, or plain JavaScript objects.</desc>
+    <argument name="deferreds">
+      <desc>Zero or more Thenable objects.</desc>
+      <type name="Deferred"/>
+      <type name="Promise"/>
+      <type name="Thenable"/>
     </argument>
   </signature>
-  <desc>Provides a way to execute callback functions based on zero or more objects, usually <a href="/category/deferred-object/">Deferred</a> objects that represent asynchronous events.</desc>
+  <desc>Provides a way to execute callback functions based on zero or more Thenable objects, usually <a href="/category/deferred-object/">Deferred</a> objects that represent asynchronous events.</desc>
   <longdesc>
     <p>If no arguments are passed to <code>jQuery.when()</code>, it will return a resolved Promise.</p>
     <p>If a single Deferred is passed to <code>jQuery.when()</code>, its Promise object (a subset of the Deferred methods) is returned by the method. Additional methods of the Promise object can be called to attach callbacks, such as <a href="/deferred.then/"><code>deferred.then</code></a>. When the Deferred is resolved or rejected, usually by the code that created the Deferred originally, the appropriate callbacks will be called. For example, the jqXHR object returned by <code>jQuery.ajax()</code> is a Promise-compatible object and can be used this way:</p>

--- a/pages/Types.html
+++ b/pages/Types.html
@@ -93,6 +93,7 @@ var x = "";
   <li class="toclevel-1"><a href="#jQuery"><span class="toctext">jQuery</span></a></li>
   <li class="toclevel-1"><a href="#XMLHttpRequest"><span class="toctext">XMLHttpRequest</span></a></li>
   <li class="toclevel-1"><a href="#jqXHR"><span class="toctext">jqXHR</span></a></li>
+  <li class="toclevel-1"><a href="#Thenable"><span class="toctext">Thenable</span></a></li>
   <li class="toclevel-1"><a href="#Deferred"><span class="toctext">Deferred Object</span></a></li>
   <li class="toclevel-1"><a href="#Promise"><span class="toctext">Promise Object</span></a></li>
   <li class="toclevel-1"><a href="#Callbacks"><span class="toctext">Callbacks Object</span></a></li>
@@ -657,6 +658,8 @@ console.log( obj.foo() );
 <h2 id="jqXHR"> jqXHR </h2>
 <p>As of jQuery 1.5, the <a href="/jQuery.ajax/">$.ajax()</a> method returns the jqXHR object, which is a superset of the XMLHTTPRequest object. For more information, see the <a href="/jQuery.ajax/#jqXHR">jqXHR section of the $.ajax entry</a>
 </p>
+<h2 id="Thenable">Thenable</h2>
+<p>Any object that has a <code>then</code> method.</p>
 <h2 id="Deferred"> Deferred Object</h2>
 <p>As of jQuery 1.5, the <a href="/category/deferred-object/">Deferred</a> object provides a way to register multiple callbacks into self-managed callback queues, invoke callback queues as appropriate, and relay the success or failure state of any synchronous or asynchronous function.
 </p>


### PR DESCRIPTION
Technically replacing Deferred with Thenable would work, but mentioning Deferred and Promise directly should make this easier to understand for new and existing users.

Fixes #906.