### PR TITLE
Remove delegated on example

### DIFF
--- a/entries/on.xml
+++ b/entries/on.xml
@@ -265,14 +265,6 @@ $( "body" ).on( "click", "p", function() {
 ]]></code>
   </example>
   <example>
-    <desc>Cancel a link's default action using the <code>.preventDefault()</code> method:</desc>
-    <code><![CDATA[
-$( "body" ).on( "click", "a", function( event ) {
-  event.preventDefault();
-});
-]]></code>
-  </example>
-  <example>
     <desc>Attach multiple events—one on <code>mouseenter</code> and one on <code>mouseleave</code> to the same element:</desc>
     <code><![CDATA[
 $( "#cart" ).on( "mouseenter mouseleave", function( event ) {


### PR DESCRIPTION
This example doesn't work since the link will have opened before the event has bubbled up to body.