### PR TITLE
Types: Updated XMLHttpRequest standard link

### DIFF
--- a/pages/Types.html
+++ b/pages/Types.html
@@ -645,9 +645,9 @@ console.log( obj.foo() );
 <h2 id="XMLHttpRequest"> XMLHttpRequest </h2>
 <p>Some of jQuery's Ajax functions return the native XMLHttpRequest (XHR) object, or pass it as an argument to success/error/complete handlers, so that you can do additional processing or monitoring on the request. Note that Ajax functions only return or pass an XHR object when an XHR object is actually used in the request. For example, JSONP requests and cross-domain GET requests use a script element rather than an XHR object.
 </p>
-<p>Although the XHR object is a standard, there are variations in its behavior on different browsers. Refer to the W3C site and browsers' documentation for more information:
+<p>Although the XHR object is a standard, there are variations in its behavior on different browsers. Refer to the WHATWG site and browsers' documentation for more information:
 </p>
-<ul><li> <a href="http://www.w3.org/TR/XMLHttpRequest/" class="external text" title="http://www.w3.org/TR/XMLHttpRequest/">W3C standard</a>
+<ul><li> <a href="https://xhr.spec.whatwg.org/" class="external text" title="https://xhr.spec.whatwg.org/">WHATWG living standard</a>
 </li><li> <a href="http://developer.apple.com/internet/webcontent/xmlhttpreq.html" class="external text" title="http://developer.apple.com/internet/webcontent/xmlhttpreq.html">Apple (Safari)</a>
 </li><li> <a href="https://developer.mozilla.org/docs/en/DOM/XMLHttpRequest" class="external text" title="http://developer.mozilla.org/en/xmlhttprequest">Mozilla (Firefox)</a>
 </li><li> <a href="http://msdn.microsoft.com/en-us/library/ms535874%28VS.85%29.aspx" class="external text" title="http://msdn.microsoft.com/en-us/library/ms535874%28VS.85%29.aspx">Microsoft (Internet Explorer)</a>


### PR DESCRIPTION
W3C's XMLHttpRequest standardization process has been discontinued.
Documentation now refers to the WHATWG living standard.

Fixes: #1043