### PR TITLE
add accepted param types for html method

### DIFF
--- a/entries/html.xml
+++ b/entries/html.xml
@@ -68,8 +68,11 @@ $( "p" ).click(function() {
   <entry type="method" name="html" return="jQuery">
     <signature>
       <added>1.0</added>
-      <argument name="htmlString" type="htmlString">
-        <desc>A string of HTML to set as the content of each matched element.</desc>
+      <argument name="content">
+        <desc>A string of HTML, DOM element, or array of strings or elements to set as the content of each matched element.</desc>
+        <type name="htmlString"/>
+        <type name="Element"/>
+        <type name="Array"/>
       </argument>
     </signature>
     <signature>

--- a/entries/html.xml
+++ b/entries/html.xml
@@ -71,7 +71,7 @@ $( "p" ).click(function() {
       <argument name="content">
         <desc>A string of HTML, DOM element, or array of strings or elements to set as the content of each matched element.</desc>
         <type name="htmlString"/>
-        <type name="Element"/>
+        <type name="jQuery"/>
         <type name="Array"/>
       </argument>
     </signature>


### PR DESCRIPTION
Noticed that `.html()` accepts more than just an `htmlString` but the docs don't reflect this.