### PR TITLE
Fix signatures of multiple functions

### DIFF
--- a/entries/callbacks.fireWith.xml
+++ b/entries/callbacks.fireWith.xml
@@ -3,11 +3,13 @@
   <title>callbacks.fireWith()</title>
   <signature>
     <added>1.7</added>
-    <argument name="context" optional="true" type="Anything">
+    <argument name="context" optional="true" type="Object">
       <desc>A reference to the context in which the callbacks in the list should be fired.</desc>
     </argument>
-    <argument name="args" optional="true" type="Array">
-      <desc>An array of arguments to pass to the callbacks in the list. If omitted or undefined, no arguments will be passed.</desc>
+    <argument name="args" optional="true">
+      <desc>An argument, or array of arguments, to pass to the callbacks in the list.</desc>
+      <type name="Array"/>
+      <type name="Anything"/>
     </argument>
   </signature>
   <desc>Call all callbacks in a list with the given context and arguments.</desc>

--- a/entries/callbacks.fireWith.xml
+++ b/entries/callbacks.fireWith.xml
@@ -3,13 +3,11 @@
   <title>callbacks.fireWith()</title>
   <signature>
     <added>1.7</added>
-    <argument name="context" optional="true" type="Object">
+    <argument name="context" optional="true" type="Anything">
       <desc>A reference to the context in which the callbacks in the list should be fired.</desc>
     </argument>
-    <argument name="args" optional="true">
-      <desc>An argument, or array of arguments, to pass to the callbacks in the list.</desc>
-      <type name="Array"/>
-      <type name="Anything"/>
+    <argument name="args" optional="true" type="ArrayLikeObject">
+      <desc>An array or array-like object of arguments to pass to the callbacks in the list. If omitted or undefined, no arguments will be passed.</desc>
     </argument>
   </signature>
   <desc>Call all callbacks in a list with the given context and arguments.</desc>

--- a/entries/callbacks.fireWith.xml
+++ b/entries/callbacks.fireWith.xml
@@ -3,11 +3,11 @@
   <title>callbacks.fireWith()</title>
   <signature>
     <added>1.7</added>
-    <argument name="context" optional="true">
+    <argument name="context" optional="true" type="Anything">
       <desc>A reference to the context in which the callbacks in the list should be fired.</desc>
     </argument>
-    <argument name="args" optional="true">
-      <desc>An argument, or array of arguments, to pass to the callbacks in the list.</desc>
+    <argument name="args" optional="true" type="Array">
+      <desc>An array of arguments to pass to the callbacks in the list. If omitted or undefined, no arguments will be passed.</desc>
     </argument>
   </signature>
   <desc>Call all callbacks in a list with the given context and arguments.</desc>

--- a/entries/event.stopImmediatePropagation.xml
+++ b/entries/event.stopImmediatePropagation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="event.stopImmediatePropagation" return="">
+<entry type="method" name="event.stopImmediatePropagation" return="undefined">
   <title>event.stopImmediatePropagation()</title>
   <signature>
     <added>1.3</added>

--- a/entries/event.stopPropagation.xml
+++ b/entries/event.stopPropagation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="event.stopPropagation" return="">
+<entry type="method" name="event.stopPropagation" return="undefined">
   <title>event.stopPropagation()</title>
   <signature>
     <added>1.0</added>

--- a/entries/jQuery.ajaxSetup.xml
+++ b/entries/jQuery.ajaxSetup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="jQuery.ajaxSetup" return="">
+<entry type="method" name="jQuery.ajaxSetup" return="PlainObject">
   <title>jQuery.ajaxSetup()</title>
   <signature>
     <added>1.1</added>

--- a/entries/jQuery.globalEval.xml
+++ b/entries/jQuery.globalEval.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="jQuery.globalEval" return="">
+<entry type="method" name="jQuery.globalEval" return="Anything">
   <title>jQuery.globalEval()</title>
   <signature>
     <added>1.0.4</added>


### PR DESCRIPTION
Following #1066, I have found several functions without a return type. I have assigned appropriate types to these. I have additionally figured out the signature of callbacks.callWith, and fixed that as well. The documentation had a mistake in it, it stated that if the argument is not an array, the callbacks will receive a single argument, but this is not true, it is in fact passed as the second argument of apply.

Finally, I have not assigned a return type to jQuery.error, as it never returns therefore has no return type.

I agree to the CLA. Do I need any paperwork? EDIT: Figured it out.