### PR TITLE
Update description to include return value information

### DIFF
--- a/entries/unwrap.xml
+++ b/entries/unwrap.xml
@@ -12,7 +12,7 @@
   </signature>
   <desc>Remove the parents of the set of matched elements from the DOM, leaving the matched elements in their place.</desc>
   <longdesc>
-    <p>The <code>.unwrap()</code> method removes the element's parent. This is effectively the inverse of the <code><a href="/wrap/">.wrap()</a></code> method. The matched elements (and their siblings, if any) replace their parents within the DOM structure.</p>
+    <p>The <code>.unwrap()</code> method removes the element's parent and returns the unwrapped content. This is effectively the inverse of the <code><a href="/wrap/">.wrap()</a></code> method. The matched elements (and their siblings, if any) replace their parents within the DOM structure.</p>
   </longdesc>
   <example>
     <desc>Wrap/unwrap a div around each of the paragraphs.</desc>


### PR DESCRIPTION
The `.unwrap()` method returns whatever content was unwrapped. Adding this to the description so that the behavior is documented.