### PR TITLE
Fix Example for https

### DIFF
--- a/entries/jQuery.getJSON.xml
+++ b/entries/jQuery.getJSON.xml
@@ -95,7 +95,7 @@ jqxhr.complete(function() {
     <desc>Loads the four most recent pictures of Mount Rainier from the Flickr JSONP API.</desc>
     <code><![CDATA[
 (function() {
-  var flickerAPI = "http://api.flickr.com/services/feeds/photos_public.gne?jsoncallback=?";
+  var flickerAPI = "https://api.flickr.com/services/feeds/photos_public.gne?jsoncallback=?";
   $.getJSON( flickerAPI, {
     tags: "mount rainier",
     tagmode: "any",


### PR DESCRIPTION
Error was:

Mixed Content: The page at 'https://api.jquery.com/jquery.getjson/' was loaded over HTTPS, but requested an insecure script 'http://api.flickr.com/services/feeds/photos_public.gne?jsoncallback=jQuery110203890736409927371_1513688901634&tags=mount+rainier&tagmode=any&format=json&_=1513688901635'. This request has been blocked; the content must be served over HTTPS.