### PR TITLE
Update find.xml

### DIFF
--- a/entries/find.xml
+++ b/entries/find.xml
@@ -18,7 +18,7 @@
   <desc>Get the descendants of each element in the current set of matched elements, filtered by a selector, jQuery object, or element.</desc>
   <longdesc>
     <p>Given a jQuery object that represents a set of DOM elements, the <code>.find()</code> method allows us to search through the descendants of these elements in the DOM tree and construct a new jQuery object from the matching elements. The <code>.find()</code> and <code>.children()</code> methods are similar, except that the latter only travels a single level down the DOM tree.</p>
-    <p>The first signature for the <code>.find()</code>method accepts a selector expression of the same type that we can pass to the <code>$()</code> function. The elements will be filtered by testing whether they match this selector, and that each selector in the list is a descendant so that elements outside the scoping root are not considered. The expressions allowed include selectors like <code>&gt; p</code> which will find all the paragraphs that are children of the elements in the jQuery object.</p>
+    <p>The first signature for the <code>.find()</code>method accepts a selector expression of the same type that we can pass to the <code>$()</code> function. The elements will be filtered by testing whether they match this selector; all parts of the selector must lie inside of an element on which .find() is called. The expressions allowed include selectors like <code>&gt; p</code> which will find all the paragraphs that are children of the elements in the jQuery object.</p>
     <p>Consider a page with a basic nested list on it:</p>
     <pre><code>
 &lt;ul class="level-1"&gt;

--- a/entries/find.xml
+++ b/entries/find.xml
@@ -18,7 +18,7 @@
   <desc>Get the descendants of each element in the current set of matched elements, filtered by a selector, jQuery object, or element.</desc>
   <longdesc>
     <p>Given a jQuery object that represents a set of DOM elements, the <code>.find()</code> method allows us to search through the descendants of these elements in the DOM tree and construct a new jQuery object from the matching elements. The <code>.find()</code> and <code>.children()</code> methods are similar, except that the latter only travels a single level down the DOM tree.</p>
-    <p>The first signature for the <code>.find()</code>method accepts a selector expression of the same type that we can pass to the <code>$()</code> function. The elements will be filtered by testing whether they match this selector. The expressions allowed include selectors like <code>&gt; p</code> which will find all the paragraphs that are children of the elements in the jQuery object.</p>
+    <p>The first signature for the <code>.find()</code>method accepts a selector expression of the same type that we can pass to the <code>$()</code> function. The elements will be filtered by testing whether they match this selector, and that each selector in the list is a descendant so that elements outside the scoping root are not considered. The expressions allowed include selectors like <code>&gt; p</code> which will find all the paragraphs that are children of the elements in the jQuery object.</p>
     <p>Consider a page with a basic nested list on it:</p>
     <pre><code>
 &lt;ul class="level-1"&gt;


### PR DESCRIPTION
"The elements will be filtered by testing whether they match this selector." isn't exactly accurate, as any selector in the selector list that isn't a descendant of the originating element gets excluded per https://github.com/jquery/jquery/blob/cf84696fd1d7fe314a11492606529b5a658ee9e3/external/sizzle/dist/sizzle.js#L306

"qSA considers elements outside a scoping root when evaluating child or
descendant combinators, which is not what we want.
In such cases, we work around the behavior by prefixing every selector in the
list with an ID selector referencing the scope context."

This is an important note, because it is contrary to how the native JS `querySelectorAll` function works, which doesn't do any such excluding (see https://stackoverflow.com/questions/56156003/jquery-find-not-finding-elements-that-match-this-selector)