### PR TITLE
All: Upgrade jQuery used in examples from 1.10.2 to 3.4.1, remove deprecated examples

### DIFF
--- a/entries/andSelf.xml
+++ b/entries/andSelf.xml
@@ -6,72 +6,10 @@
   </signature>
   <desc>Add the previous set of elements on the stack to the current set.</desc>
   <longdesc>
-    <p><strong>Note:</strong> This function has been deprecated and is now an alias for <a href="/addBack/"><code>.addBack()</code></a>, which should be used with jQuery 1.8 and later.</p>
-    <p>As described in the discussion for <code><a href="/end/">.end()</a></code>, jQuery objects maintain an internal stack that keeps track of changes to the matched set of elements. When one of the DOM traversal methods is called, the new set of elements is pushed onto the stack. If the previous set of elements is desired as well, <code>.andSelf()</code> can help.</p>
-    <p>Consider a page with a simple list on it:</p>
-    <pre><code>
-&lt;ul&gt;
-  &lt;li&gt;list item 1&lt;/li&gt;
-  &lt;li&gt;list item 2&lt;/li&gt;
-  &lt;li class="third-item"&gt;list item 3&lt;/li&gt;
-  &lt;li&gt;list item 4&lt;/li&gt;
-  &lt;li&gt;list item 5&lt;/li&gt;
-&lt;/ul&gt;
-    </code></pre>
-    <p>The result of the following code is a red background behind items 3, 4 and 5:</p>
-    <pre><code>
-$( "li.third-item" ).nextAll().andSelf()
-  .css( "background-color", "red" );
-    </code></pre>
-    <p>First, the initial selector locates item 3, initializing the stack with the set containing just this item. The call to <code>.nextAll()</code> then pushes the set of items 4 and 5 onto the stack. Finally, the <code>.andSelf()</code> invocation merges these two sets together, creating a jQuery object that points to all three items in document order: <code>[ &lt;li.third-item&gt;, &lt;li&gt;, &lt;li&gt; ]</code>.</p>
+    <div class="warning">
+      <p>Note: This API has been removed in jQuery 3.0; use <a href="/addBack/"><code>.addBack()</code></a> instead, which should work identically.</p>
+    </div>
   </longdesc>
-  <example>
-    <desc>The <code>.andSelf()</code> method causes the previous set of DOM elements in the traversal stack to be added to the current set. In the first example, the top stack contains the set resulting from <code>.find("p")</code>. In the second example, <code>.andSelf()</code> adds the previous set of elements on the stack — in this case <code>$( "div.after-andself" )</code> — to the current set, selecting both the div and its enclosed paragraphs.</desc>
-    <code><![CDATA[
-$( "div.left, div.right" ).find( "div, div > p" ).addClass( "border" );
-
-// First Example
-$( "div.before-andself" ).find( "p" ).addClass( "background" );
-
-// Second Example
-$( "div.after-andself" ).find( "p" ).andSelf().addClass( "background" );
-]]></code>
-    <css><![CDATA[
-  p, div {
-    margin: 5px;
-    padding: 5px;
-  }
-  .border {
-    border: 2px solid red;
-  }
-  .background {
-    background: yellow;
-  }
-  .left, .right {
-    width: 45%;
-    float: left;
-  }
-  .right {
-    margin-left: 3%;
-  }
-]]></css>
-    <html><![CDATA[
-<div class="left">
-  <p><strong>Before <code>andSelf()</code></strong></p>
-  <div class="before-andself">
-    <p>First Paragraph</p>
-    <p>Second Paragraph</p>
-  </div>
-</div>
-<div class="right">
-  <p><strong>After <code>andSelf()</code></strong></p>
-  <div class="after-andself">
-    <p>First Paragraph</p>
-    <p>Second Paragraph</p>
-  </div>
-</div>
-]]></html>
-  </example>
   <category slug="traversing/miscellaneous-traversal"/>
   <category slug="version/1.2"/>
   <category slug="deprecated/deprecated-1.8"/>

--- a/entries/context.xml
+++ b/entries/context.xml
@@ -6,7 +6,9 @@
   </signature>
   <desc>The DOM node context originally passed to <code>jQuery()</code>; if none was passed then context will likely be the document.</desc>
   <longdesc>
-    <p>The <code>.context</code> property was deprecated in jQuery 1.10 and is only maintained to the extent needed for supporting <code>.live()</code> in the jQuery Migrate plugin. It may be removed without notice in a future version.</p>
+    <div class="warning">
+      <p>Note: This API has been removed in jQuery 3.0.</p>
+    </div>
     <p>The <code>.live()</code> method for binding event handlers uses this property to determine the root element to use for its event delegation needs.</p>
     <p>The value of this property is typically equal to <code>document</code>, as this is the default context for jQuery objects if none is supplied. The context may differ if, for example, the object was created by searching within an <code>&lt;iframe&gt;</code> or XML document.</p>
     <p>Note that the context property may only apply to the elements originally selected by <code>jQuery()</code>, as it is possible for the user to add elements to the collection via methods such as <code>.add()</code> and these may have a different context.</p>
@@ -18,9 +20,6 @@ $( "ul" )
   .append( "<li>" + $( "ul" ).context + "</li>" )
   .append( "<li>" + $( "ul", document.body ).context.nodeName + "</li>" );
 ]]></code>
-    <html><![CDATA[
-Context: <ul></ul>
-]]></html>
   </example>
   <category slug="internals"/>
   <category slug="properties/jquery-object-instance-properties"/>

--- a/entries/deferred.isRejected.xml
+++ b/entries/deferred.isRejected.xml
@@ -6,7 +6,9 @@
   </signature>
   <desc> Determine whether a Deferred object has been rejected. </desc>
   <longdesc>
-    <p>As of jQuery 1.7 this API has been deprecated; please use <a href="/deferred.state/"><code>deferred.state()</code></a> instead.</p>
+    <div class="warning">
+      <p>Note: This API has been removed in jQuery 1.8; please use <a href="/deferred.state/"><code>deferred.state()</code></a> instead.</p>
+    </div>
     <p>Returns <code>true</code> if the Deferred object is in the rejected state, meaning that either <a href="h/deferred.reject/"><code>deferred.reject()</code></a> or <a href="/deferred.rejectWith/"><code>deferred.rejectWith()</code></a> has been called for the object and the failCallbacks have been called (or are in the process of being called).</p>
     <p>Note that a Deferred object can be in one of three states: pending, resolved, or rejected; use <a href="/deferred.isResolved/"><code>deferred.isResolved()</code></a> to determine whether the Deferred object is in the resolved state. These methods are primarily useful for debugging, for example to determine whether a Deferred has already been resolved even though you are inside code that intended to reject it.</p>
   </longdesc>

--- a/entries/deferred.isResolved.xml
+++ b/entries/deferred.isResolved.xml
@@ -6,7 +6,9 @@
   </signature>
   <desc> Determine whether a Deferred object has been resolved. </desc>
   <longdesc>
-    <p>This API is <code>deprecated</code> as of jQuery 1.7 and <code>removed</code> as of jQuery 1.8; please use <a href="/deferred.state/"><code>deferred.state()</code></a> instead.</p>
+    <div class="warning">
+      <p>Note: This API has been removed in jQuery 1.8; please use <a href="/deferred.state/"><code>deferred.state()</code></a> instead.</p>
+    </div>
     <p>Returns <code>true</code> if the Deferred object is in the resolved state, meaning that either <a href="/deferred.resolve/"><code>deferred.resolve()</code></a> or <a href="/deferred.resolveWith/"><code>deferred.resolveWith()</code></a> has been called for the object and the doneCallbacks have been called (or are in the process of being called).</p>
     <p>Note that a Deferred object can be in one of three states: pending, resolved, or rejected; use <a href="/deferred.isRejected/"><code>deferred.isRejected()</code></a> to determine whether the Deferred object is in the rejected state. These methods are primarily useful for debugging, for example to determine whether a Deferred has already been resolved even though you are inside code that intended to reject it.</p>
   </longdesc>

--- a/entries/die.xml
+++ b/entries/die.xml
@@ -21,6 +21,9 @@
     </argument>
   </signature>
   <longdesc>
+    <div class="warning">
+      <p>Note: This API has been removed in jQuery 1.9; please use <a href="/on/"><code>on()</code></a> instead.</p>
+    </div>
     <p>Any handler that has been attached with <code>.live()</code> can be removed with <code>.die()</code>. This method is analogous to calling <code>.off()</code> with no arguments, which is used to remove all handlers attached with <code>.on()</code>.
   See the discussions of <code>.live()</code> and <code>.off()</code> for further details.</p>
     <p>If used without an argument, .die() removes <em>all</em> event handlers previously attached using <code>.live()</code> from the elements.</p>

--- a/entries/error.xml
+++ b/entries/error.xml
@@ -20,8 +20,9 @@
     </argument>
   </signature>
   <longdesc>
-    <p>This method is a shortcut for <code>.on( "error", handler )</code>.</p>
-    <p><b>As of jQuery 1.8</b>, the <code>.error()</code> method is deprecated. Use <code>.on( "error", handler )</code> to attach event handlers to the <code>error</code> event instead.</p>
+    <div class="warning">
+      <p>Note: This API has been removed in jQuery 3.0; please use <code>.on( "error", handler )</code> instead of <code>.error( handler )</code> and <code>.trigger( "error" )</code> instead of <code>.error()</code>.</p>
+    </div>
     <p>The <code>error</code> event is sent to elements, such as images, that are referenced by a document and loaded by the browser. It is called if the element was not loaded correctly.</p>
     <p>For example, consider a page with a simple image element:</p>
     <pre><code>

--- a/entries/jQuery.boxModel.xml
+++ b/entries/jQuery.boxModel.xml
@@ -4,8 +4,12 @@
   <signature>
     <added>1.0</added>
   </signature>
-  <desc>States if the current page, in the user's browser, is being rendered using the <a href="https://www.w3.org/TR/REC-CSS2/box.html">W3C CSS Box Model</a>. <strong>This property was removed in jQuery 1.8</strong>. Please try to use feature detection instead.</desc>
-  <longdesc/>
+  <desc>States if the current page, in the user's browser, is being rendered using the <a href="https://www.w3.org/TR/REC-CSS2/box.html">W3C CSS Box Model</a>.</desc>
+  <longdesc>
+    <div class="warning">
+      <p>Note: This API has been removed in jQuery 3.0; check if <code>.document.compatMode</code> is equal to <code>"CSS1Compat"</code> instead. Or, even better - always specify a DOCTYPE and avoid using quirks mode which jQuery doesn't support.</p>
+    </div>
+  </longdesc>
   <category slug="utilities"/>
   <category slug="version/1.0"/>
   <category slug="deprecated/deprecated-1.3"/>

--- a/entries/jQuery.browser.xml
+++ b/entries/jQuery.browser.xml
@@ -7,6 +7,9 @@
     </signature>
     <desc>Contains flags for the useragent, read from navigator.userAgent. <strong>This property was removed in jQuery 1.9</strong> and is available only through the jQuery.migrate plugin. Please try to use feature detection instead.</desc>
     <longdesc>
+      <div class="warning">
+        <p>Note: This API has been removed in jQuery 1.9; please rely on feature detection instead.</p>
+      </div>
       <p>The <code>$.browser</code> property provides information about the web browser that is accessing the page, as reported by the browser itself. It contains flags for each of the four most prevalent browser classes (Internet Explorer, Mozilla, Webkit, and Opera) as well as version information.</p>
       <p>Available flags are:</p>
       <ul>
@@ -56,6 +59,9 @@ $.browser.msie;
     </signature>
     <desc>The version number of the rendering engine for the user's browser. <strong>This property was removed in jQuery 1.9</strong> and is available only through the jQuery.migrate plugin.</desc>
     <longdesc>
+      <div class="warning">
+        <p>Note: This API has been removed in jQuery 1.9; please rely on feature detection instead.</p>
+      </div>
       <p>Here are some typical results:</p>
       <ul>
         <li>Internet Explorer: 6.0, 7.0, 8.0</li>

--- a/entries/jQuery.sub.xml
+++ b/entries/jQuery.sub.xml
@@ -6,9 +6,9 @@
   </signature>
   <desc>Creates a new copy of jQuery whose properties and methods can be modified without affecting the original jQuery object.</desc>
   <longdesc>
-    <p>
-      <strong>This method is deprecated as of jQuery 1.7 and will be moved to a plugin in jQuery 1.8.</strong>
-    </p>
+    <div class="warning">
+      <p>Note: This API has been removed in jQuery 1.9.</p>
+    </div>
     <p>There are two specific use cases for which jQuery.sub() was created. The first was for providing a painless way of overriding jQuery methods without completely destroying the original methods and another was for helping to do encapsulation and basic namespacing for jQuery plugins.</p>
     <p>Note that jQuery.sub() doesn't attempt to do any sort of isolation - that's not its intention. All the methods on the sub'd version of jQuery will still point to the original jQuery (events bound and triggered will still be through the main jQuery, data will be bound to elements through the main jQuery, Ajax queries and events will run through the main jQuery, etc.).</p>
     <p>Note that if you're looking to use this for plugin development you should first <i>strongly</i> consider using something like the jQuery UI widget factory which manages both state and plugin sub-methods. <a href="http://blog.nemikor.com/2010/05/15/building-stateful-jquery-plugins/">Some examples of using the jQuery UI widget factory</a> to build a plugin.</p>

--- a/entries/live.xml
+++ b/entries/live.xml
@@ -32,7 +32,9 @@
     </argument>
   </signature>
   <longdesc>
-    <p><strong>As of jQuery 1.7</strong>, the <code>.live()</code> method is deprecated. Use <a href="/on/"><code>.on()</code></a> to attach event handlers. Users of older versions of jQuery should use <a href="/delegate/"><code>.delegate()</code></a> in preference to <code>.live()</code>.</p>
+    <div class="warning">
+      <p>Note: This API has been removed in jQuery 1.9; please use <a href="/on/"><code>on()</code></a> instead.</p>
+    </div>
     <p>This method provides a means to attach delegated event handlers to the <code>document</code> element of a page, which simplifies the use of event handlers when content is dynamically added to a page. See the discussion of direct versus delegated events in the <a href="/on/"><code>.on()</code></a> method for more information. </p>
     <p>Rewriting the <code>.live()</code> method in terms of its successors is straightforward; these are templates for equivalent calls for all three event attachment methods:</p>
     <pre><code>

--- a/entries/load-event.xml
+++ b/entries/load-event.xml
@@ -20,6 +20,9 @@
     </argument>
   </signature>
   <longdesc>
+    <div class="warning">
+      <p>Note: This API has been removed in jQuery 3.0; please use <code>.on( "load", handler )</code> instead of <code>.load( handler )</code> and <code>.trigger( "load" )</code> instead of <code>.load()</code>.</p>
+    </div>
     <p>This method is a shortcut for <code>.on( "load", handler )</code>.</p>
     <p>The <code>load</code> event is sent to an element when it and all sub-elements have been completely loaded. This event can be sent to any element associated with a URL: images, scripts, frames, iframes, and the <code>window</code> object.</p>
     <p>For example, consider a page with a simple image:</p>

--- a/entries/selector.xml
+++ b/entries/selector.xml
@@ -6,7 +6,9 @@
   </signature>
   <desc>A selector representing selector passed to jQuery(), if any, when creating the original set.</desc>
   <longdesc>
-    <p>The <code>.selector</code> property was deprecated in jQuery 1.7 and is only maintained to the extent needed for supporting <code>.live()</code> in the jQuery Migrate plugin. It may be removed without notice in a future version. The property was never a reliable indicator of the selector that could be used to obtain the set of elements currently contained in the jQuery set where it was a property, since subsequent traversal methods may have changed the set. Plugins that need to use a selector string within their plugin can require it as a parameter of the method. For example, a "foo" plugin could be written as <code>$.fn.foo = function( selector, options ) { /* plugin code goes here */ };</code>, and the person using the plugin would write <code>$( "div.bar" ).foo( "div.bar", {dog: "bark"} );</code> with the <code>"div.bar"</code> selector repeated as the first argument of <code>.foo()</code>.</p>
+    <div class="warning">
+      <p>Note: This API has been removed in jQuery 3.0. The property was never a reliable indicator of the selector that could be used to obtain the set of elements currently contained in the jQuery set where it was a property, since subsequent traversal methods may have changed the set. Plugins that need to use a selector string within their plugin can require it as a parameter of the method. For example, a "foo" plugin could be written as <code>$.fn.foo = function( selector, options ) { /* plugin code goes here */ };</code>, and the person using the plugin would write <code>$( "div.bar" ).foo( "div.bar", {dog: "bark"} );</code> with the <code>"div.bar"</code> selector repeated as the first argument of <code>.foo()</code>.</p>
+    </div>
   </longdesc>
   <category slug="internals"/>
   <category slug="properties/jquery-object-instance-properties"/>

--- a/entries/size.xml
+++ b/entries/size.xml
@@ -6,7 +6,9 @@
   </signature>
   <desc>Return the number of elements in the jQuery object.</desc>
   <longdesc>
-    <p>The <code>.size()</code> method is deprecated as of jQuery 1.8. Use the <code><a href="/length/">.length</a></code> property instead.</p>
+    <div class="warning">
+      <p>Note: This method has been removed in jQuery 3.0. Use the <code><a href="/length/">.length</a></code> property instead.</p>
+    </div>
 
     <p>The <code>.size()</code> method is functionally equivalent to the <code><a href="/length/">.length</a></code> property; however, <strong>the <code>.length</code> property is preferred</strong> because it does not have the overhead of a function call.</p>
     <p>Given a simple unordered list on the page:</p>
@@ -30,7 +32,7 @@ alert( "Size: " + $( "li" ).length );
     </p>
   </longdesc>
   <example>
-    <desc>Count the divs. Click to add more.</desc>
+    <desc>Count the divs.</desc>
     <code><![CDATA[
 $( document.body )
   .click(function() {
@@ -42,26 +44,6 @@ $( document.body )
   // Trigger the click to start
   .click();
 ]]></code>
-    <css><![CDATA[
-  body {
-    cursor: pointer;
-    min-height: 100px;
-  }
-  div {
-    width: 50px;
-    height: 30px;
-    margin: 5px;
-    float: left;
-    background: blue;
-  }
-  span {
-    color: red;
-  }
-]]></css>
-    <html><![CDATA[
-<span></span>
-<div></div>
-]]></html>
   </example>
   <category slug="miscellaneous/dom-element-methods"/>
   <category slug="version/1.0"/>

--- a/entries/unload.xml
+++ b/entries/unload.xml
@@ -20,6 +20,9 @@
   </signature>
   <desc>Bind an event handler to the "unload" JavaScript event.</desc>
   <longdesc>
+    <div class="warning">
+      <p>Note: This API has been removed in jQuery 3.0; please use <code>.on( "unload", handler )</code> instead of <code>.unload( handler )</code> and <code>.trigger( "unload" )</code> instead of <code>.unload()</code>.</p>
+    </div>
     <p>This method is a shortcut for <code>.on( "unload", handler )</code>.</p>
     <p>The <code>unload</code> event is sent to the <code>window</code> element when the user navigates away from the page. This could mean one of many things. The user could have clicked on a link to leave the page, or typed in a new URL in the address bar. The forward and back buttons will trigger the event. Closing the browser window will cause the event to be triggered. Even a page reload will first create an <code>unload</code> event.</p>
     <div class="warning">

--- a/entries2html.xsl
+++ b/entries2html.xsl
@@ -12,7 +12,7 @@
 	&lt;meta charset="utf-8"&gt;
 	&lt;title&gt;<xsl:value-of select="//entry/@name"/> demo&lt;/title&gt;<xsl:if test="css">
 	&lt;style&gt;<xsl:value-of select="css/text()"/>	&lt;/style&gt;</xsl:if>
-	&lt;script src="https://code.jquery.com/jquery-1.10.2.js"&gt;&lt;/script&gt;<xsl:if test="code/@location='head'">
+	&lt;script src="https://code.jquery.com/jquery-3.4.1.js"&gt;&lt;/script&gt;<xsl:if test="code/@location='head'">
 	&lt;script&gt;
 	<xsl:copy-of select="code/text()"/>
 	&lt;/script&gt;


### PR DESCRIPTION
The upgrade is necessary to be able to write examples for newer APIs.
Examples for removed APIs have been removed as they'd no longer work.

Fixes gh-982