### PR TITLE
jQuery.get: Add an example using a root-relative path

### DIFF
--- a/entries/jQuery.get.xml
+++ b/entries/jQuery.get.xml
@@ -131,8 +131,8 @@ $.get( "test.php", function( data ) {
 // If this was sent on https://api.jquery.com/jQuery.get/ you will
 // get the response result of https://api.jquery.com/jQuery.ajax/
 $.get( "/jQuery.ajax/", function( data ) {
-  console.log( typeof data );
-  console.log( data );
+  console.log( typeof data ); // string
+  console.log( data ); // HTML content of the jQuery.ajax page
 });
 ]]></code>
   </example>

--- a/entries/jQuery.get.xml
+++ b/entries/jQuery.get.xml
@@ -131,7 +131,7 @@ $.get( "test.php", function( data ) {
 // If this was sent on https://api.jquery.com/jQuery.get/ you will
 // get the response result of https://api.jquery.com/jQuery.ajax/
 $.get( "/jQuery.ajax/", function( data ) {
-  console.log( typeof( data ) );
+  console.log( typeof data );
   console.log( data );
 });
 ]]></code>

--- a/entries/jQuery.get.xml
+++ b/entries/jQuery.get.xml
@@ -116,13 +116,24 @@ $.get( "test.cgi", { name: "John", time: "2pm" } )
 ]]></code>
   </example>
   <example>
-    <desc> Get the test.php page contents, which has been returned in json format (&lt;?php echo json_encode( array( "name"=&gt;"John","time"=&gt;"2pm" ) ); ?&gt;), and add it to the page.</desc>
+    <desc>Get the test.php page contents, which has been returned in json format (&lt;?php echo json_encode( array( "name"=&gt;"John","time"=&gt;"2pm" ) ); ?&gt;), and add it to the page.</desc>
     <code><![CDATA[
 $.get( "test.php", function( data ) {
   $( "body" )
     .append( "Name: " + data.name ) // John
     .append( "Time: " + data.time ); //  2pm
 }, "json" );
+]]></code>
+  </example>
+  <example>
+    <desc>Get another page on the same domain. Outputs to console both the data returned and the type of data returned.</desc>
+    <code><![CDATA[
+// If this was sent on https://api.jquery.com/jQuery.get/ you will
+// get the response result of https://api.jquery.com/jQuery.ajax/
+$.get( "/jQuery.ajax/", function( data ) {
+  console.log( typeof( data ) );
+  console.log( data );
+});
 ]]></code>
   </example>
   <category slug="ajax/shorthand-methods"/>


### PR DESCRIPTION
Added a `.get()` example to show how to request a different page from the same domain.

Noticed all the examples on this page were for appending to the current url rather than changing the url to another page on the same domain. May be helpful to have here.