### PR TITLE
All: Updates for jQuery 1.12/2.2-3.5

### DIFF
--- a/categories.xml
+++ b/categories.xml
@@ -71,6 +71,11 @@
         <p>For more information, see the Release Notes/Changelog at <a href="https://blog.jquery.com/2016/06/09/jquery-3-0-final-released/">https://blog.jquery.com/2016/06/09/jquery-3-0-final-released/</a></p>
       ]]></desc>
     </category>
+    <category name="Deprecated 3.2" slug="deprecated-3.2">
+      <desc><![CDATA[All the aspects of the API that were deprecated in the corresponding version of jQuery.
+        <p>For more information, see the Release Notes/Changelog at <a href="https://blog.jquery.com/2017/03/16/jquery-3-2-0-is-out/">https://blog.jquery.com/2017/03/16/jquery-3-2-0-is-out/</a></p>
+      ]]></desc>
+    </category>
     <category name="Deprecated 3.3" slug="deprecated-3.3">
       <desc><![CDATA[All the aspects of the API that were deprecated in the corresponding version of jQuery.
         <p>For more information, see the Release Notes/Changelog at <a href="https://blog.jquery.com/2018/01/19/jquery-3-3-0-a-fragrant-bouquet-of-deprecations-and-is-that-a-new-feature/">https://blog.jquery.com/2018/01/19/jquery-3-3-0-a-fragrant-bouquet-of-deprecations-and-is-that-a-new-feature/</a></p>
@@ -79,6 +84,11 @@
     <category name="Deprecated 3.4" slug="deprecated-3.4">
       <desc><![CDATA[All the aspects of the API that were deprecated in the corresponding version of jQuery.
         <p>For more information, see the Release Notes/Changelog at <a href="https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/">https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/</a></p>
+      ]]></desc>
+    </category>
+    <category name="Deprecated 3.5" slug="deprecated-3.5">
+      <desc><![CDATA[All the aspects of the API that were deprecated in the corresponding version of jQuery.
+        <p>For more information, see the Release Notes/Changelog at <a href="https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/">https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/</a></p>
       ]]></desc>
     </category>
   </category>
@@ -429,7 +439,7 @@ var files = event.originalEvent.dataTransfer.files;
         <hr/>
       ]]></desc>
     </category>
-    <category name="Version 1.12 &amp; 2.2" slug="1.12-2.2">
+    <category name="Version 1.12 &amp; 2.2" slug="1.12-and-2.2">
       <desc><![CDATA[
         <p>Aspects of the API that were changed in the corresponding versions of jQuery. Changes in jQuery 1.12 and 2.2 includes performance improvements of the selector engine, manipulation of class names for SVG elements, support for the Symbol type and iterators added in ES2015, and a new hook has been added for filtering HTML. A <a href="https://github.com/jquery/jquery-migrate">jQuery Migrate Plugin</a> was offered to help developers with a transitional upgrade path.
         </p>
@@ -447,7 +457,36 @@ var files = event.originalEvent.dataTransfer.files;
     </category>
     <category name="Version 3.1" slug="3.1">
       <desc><![CDATA[
-        <p><a href="/jQuery.readyException">jQuery.readyException</a> was added.</p>
+        <p>Aspects of the API that were changed in the corresponding version of jQuery. Version 3.1 added the <a href="/jQuery.readyException">jQuery.readyException</a> API.</p>
+        <p>For more information, see the <a href="https://blog.jquery.com/2016/07/07/jquery-3-1-0-released-no-more-silent-errors/">Release Notes/Changelog</a></p>
+        <hr/>
+      ]]></desc>
+    </category>
+    <category name="Version 3.2" slug="3.2">
+      <desc><![CDATA[
+        <p>Aspects of the API that were changed in the corresponding version of jQuery. Version 3.2 added support for custom CSS properties, made <code>.contents()</code> work on the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template"><code>&lt;template&gt;</code> element</a> &amp; made <code>.width()</code> &amp; <code>.height()</code> ignore CSS transforms. A few APIs were deprecated. The deprecated module was added back to the slim build.</p>
+        <p>For more information, see the <a href="https://blog.jquery.com/2017/03/16/jquery-3-2-0-is-out/">Release Notes/Changelog</a></p>
+        <hr/>
+      ]]></desc>
+    </category>
+    <category name="Version 3.3" slug="3.3">
+      <desc><![CDATA[
+        <p>Aspects of the API that were changed in the corresponding version of jQuery. <code>.addClass()</code>, <code>.removeClass()</code> &amp; <code>.toggleClass()</code> now work on arrays of classes; a few APIs were deprecated.</p>
+        <p>For more information, see the <a href="https://blog.jquery.com/2018/01/19/jquery-3-3-0-a-fragrant-bouquet-of-deprecations-and-is-that-a-new-feature/">Release Notes/Changelog</a></p>
+        <hr/>
+      ]]></desc>
+    </category>
+    <category name="Version 3.4" slug="3.4">
+      <desc><![CDATA[
+        <p>Aspects of the API that were changed in the corresponding version of jQuery. <code>nonce</code> &amp; <code>nomodule</code> attributes are now preserved during script manipulation, layout thrashing was eliminated in some cases in <code>.width()</code> &amp; <code>.height()</code> APIs. Radio elements state is now updated before event handlers run. Passing data now works when triggering all events, including <code>focus</code>. A minor security fix is also included.</p>
+        <p>For more information, see the <a href="https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/">Release Notes/Changelog</a></p>
+        <hr/>
+      ]]></desc>
+    </category>
+    <category name="Version 3.5" slug="3.5">
+      <desc><![CDATA[
+        <p>Aspects of the API that were changed in the corresponding version of jQuery. Security fixes, new <code>.even()</code> &amp; <code>.odd()</code> methods; <code>jQuery.globalEval</code> now accepts context; unsuccessful HTTP script responses are no longer evaluated; performance improvements. <code>jQuery.trim</code> is now deprecated.</p>
+        <p>For more information, see the <a href="https://jquery.com/upgrade-guide/3.5/">jQuery Core 3.5 Upgrade guide</a> and the <a href="https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/">Release Notes/Changelog</a></p>
         <hr/>
       ]]></desc>
     </category>

--- a/entries/addClass.xml
+++ b/entries/addClass.xml
@@ -8,9 +8,15 @@
     </argument>
   </signature>
   <signature>
+    <added>3.3</added>
+    <argument name="classNames" type="Array">
+      <desc>An array of classes to be added to the class attribute of each matched element.</desc>
+    </argument>
+  </signature>
+  <signature>
     <added>1.4</added>
     <argument name="function" type="Function">
-      <desc>A function returning one or more space-separated class names to be added to the existing class name(s). Receives the index position of the element in the set and the existing class name(s) as arguments. Within the function, <code>this</code> refers to the current element in the set.</desc>
+      <desc>A function returning one or more space-separated classes or an array of classes to be added to the existing class name(s). Receives the index position of the element in the set and the existing class name(s) as arguments. Within the function, <code>this</code> refers to the current element in the set.</desc>
       <argument name="index" type="Integer" />
       <argument name="currentClassName" type="String" />
       <return type="String"/>
@@ -85,6 +91,29 @@ $( "p" ).last().addClass( "selected highlight" );
 ]]></html>
   </example>
   <example>
+    <desc>Add the classes "selected" and "highlight" to the matched elements (3.3+ syntax).</desc>
+    <code><![CDATA[
+$( "p" ).last().addClass( [ "selected", "highlight" ] );
+]]></code>
+    <css><![CDATA[
+  p {
+    margin: 8px;
+    font-size: 16px;
+  }
+  .selected {
+    color: red;
+  }
+  .highlight {
+    background: yellow;
+  }
+]]></css>
+    <html><![CDATA[
+<p>Hello</p>
+<p>and</p>
+<p>Goodbye</p>
+]]></html>
+  </example>
+  <example>
     <desc>Pass in a function to <code>.addClass()</code> to add the "green" class to a div that already has a "red" class.</desc>
     <code><![CDATA[
 $( "div" ).addClass(function( index, currentClass ) {
@@ -122,4 +151,6 @@ $( "div" ).addClass(function( index, currentClass ) {
   <category slug="css"/>
   <category slug="version/1.0"/>
   <category slug="version/1.4"/>
+  <category slug="version/1.12-and-2.2"/>
+  <category slug="version/3.3"/>
 </entry>

--- a/entries/contents.xml
+++ b/entries/contents.xml
@@ -8,6 +8,7 @@
   <longdesc>
     <p>Given a jQuery object that represents a set of DOM elements, the <code>.contents()</code> method allows us to search through the immediate children of these elements in the DOM tree and construct a new jQuery object from the matching elements. The <code>.contents()</code> and <code>.children()</code> methods are similar, except that the former includes text nodes and comment nodes as well as HTML elements in the resulting jQuery object. Please note that most jQuery operations don't support text nodes and comment nodes. The few that do will have an explicit note on their API documentation page.</p>
     <p>The <code>.contents()</code> method can also be used to get the content document of an iframe, if the iframe is on the same domain as the main page.</p>
+    <p><strong>As of jQuery 3.2</strong>, <code>.contents()</code> returns contents of <code>&lt;template&gt;</code> elements as well.</p>
     <p>Consider a simple <code>&lt;div&gt;</code> with a number of text nodes, each of which is separated by two line break elements (<code>&lt;br&gt;</code>):</p>
     <pre><code>
 &lt;div class="container"&gt;
@@ -60,4 +61,5 @@ $( "#frameDemo" ).contents().find( "a" ).css( "background-color", "#BADA55" );
   </example>
   <category slug="traversing/miscellaneous-traversal"/>
   <category slug="version/1.2"/>
+  <category slug="version/3.2"/>
 </entry>

--- a/entries/css.xml
+++ b/entries/css.xml
@@ -23,6 +23,7 @@
       <p>Retrieval of shorthand CSS properties (e.g., <code>margin</code>, <code>background</code>, <code>border</code>), although functional with some browsers, is not guaranteed. For example, if you want to retrieve the rendered <code>border-width</code>, use: <code>$( elem ).css( "borderTopWidth" )</code>, <code>$( elem ).css( "borderBottomWidth" )</code>, and so on.</p>
       <p>An element should be connected to the DOM when calling <code>.css()</code> on it. If it isn't, jQuery may throw an error.</p>
       <p><strong>As of jQuery 1.9</strong>, passing an array of style properties to <code>.css()</code> will result in an object of property-value pairs. For example, to retrieve all four rendered <code>border-width</code> values, you could use <code>$( elem ).css([ "borderTopWidth", "borderRightWidth", "borderBottomWidth", "borderLeftWidth" ])</code>. </p>
+      <p><strong>As of jQuery 3.2</strong>, <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/--*">CSS Custom Properties</a> (also called CSS Variables) are supported: <code>$( "p" ).css( "--custom-property" )</code>. Note that you need to provide the property name as-is, camelCasing it won't work as it does for regular CSS properties.</p>
     </longdesc>
     <example>
       <desc>Get the background color of a clicked div.</desc>
@@ -106,6 +107,7 @@ $( "div" ).click(function() {
     <category slug="version/1.0"/>
     <category slug="version/1.4"/>
     <category slug="version/1.9"/>
+    <category slug="version/3.2"/>
   </entry>
   <entry type="method" name="css" return="jQuery">
     <signature>
@@ -157,6 +159,7 @@ $( "div.example" ).css( "width", function( index ) {
       </code></pre>
       <p>This example sets the widths of the matched elements to incrementally larger values.</p>
       <p><strong>Note: </strong>If nothing is returned in the setter function (ie. <code>function( index, style ){} )</code>, or if <code>undefined</code> is returned, the current value is not changed. This is useful for selectively setting values only when certain criteria are met.</p>
+      <p><strong>As of jQuery 3.2</strong>, <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/--*">CSS Custom Properties</a> (also called CSS Variables) are supported: <code>$( "p" ).css( "--custom-property", "value" )</code>. Note that you need to provide the property name as-is, camelCasing it won't work as it does for regular CSS properties.</p>
     </longdesc>
     <example>
       <desc>Change the color of any paragraph to red on mouseover event.</desc>
@@ -282,5 +285,6 @@ $( "div" ).on( "click", function() {
     <category slug="manipulation/style-properties"/>
     <category slug="version/1.0"/>
     <category slug="version/1.4"/>
+    <category slug="version/3.2"/>
   </entry>
 </entries>

--- a/entries/eq-selector.xml
+++ b/entries/eq-selector.xml
@@ -17,7 +17,9 @@
   </signature>
   <desc>Select the element at index <code>n</code> within the matched set.</desc>
   <longdesc>
-    <p><strong>As of jQuery 3.4</strong>, the <code>:eq</code> pseudo-class is deprecated. Remove it from your selectors and filter the results later using <a href="/eq/"><code>.eq()</code></a>.</p>
+    <div class="warning">
+      <p><strong>As of jQuery 3.4</strong>, the <code>:eq</code> pseudo-class is deprecated. Remove it from your selectors and filter the results later using <a href="/eq/"><code>.eq()</code></a>.</p>
+    </div>
     <p>The index-related selectors (<code>:eq()</code>, <code>:lt()</code>, <code>:gt()</code>, <code>:even</code>, <code>:odd</code>) filter the set of elements that have matched the expressions that precede them. They narrow the set down based on the order of the elements within this matched set. For example, if elements are first selected with a class selector (<code>.myclass</code>) and four elements are returned, these elements are given indices <code>0</code> through <code>3</code> for the purposes of these selectors.</p>
     <p>Note that since JavaScript arrays use <em>0-based indexing</em>, these selectors reflect that fact. This is why <code>$( ".myclass:eq(1)" )</code> selects the second element in the document with the class myclass, rather than the first. In contrast, <code>:nth-child(n)</code> uses <em>1-based indexing</em> to conform to the CSS specification.</p>
     <p>Prior to jQuery 1.8, the <code>:eq(index)</code> selector did <em>not</em> accept a negative value for <code>index</code> (though the <a href="/eq/"><code>.eq(index)</code></a> method did).</p>

--- a/entries/even-selector.xml
+++ b/entries/even-selector.xml
@@ -5,8 +5,11 @@
   <signature>
     <added>1.0</added>
   </signature>
-  <desc>Selects even elements, zero-indexed.  See also <a href="/Selectors/odd/">odd</a>.</desc>
+  <desc>Selects even elements, zero-indexed.  See also <a href="/odd-selector/"><code>:odd</code></a>.</desc>
   <longdesc>
+    <div class="warning">
+      <p><strong>As of jQuery 3.4</strong>, the <code>:even</code> pseudo-class is deprecated. Remove it from your selectors and filter the results later using <a href="/even/"><code>.even()</code></a> (available in jQuery 3.5.0 or newer).</p>
+    </div>
     <p>In particular, note that the <em>0-based indexing</em> means that, counter-intuitively, <code>:even</code> selects the first element, third element, and so on within the matched set.</p>
   </longdesc>
   <note id="jquery-selector-extension" type="additional" data-selector=":even"/>

--- a/entries/even.xml
+++ b/entries/even.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
-<entry type="method" name="last" return="jQuery">
-  <title>.last()</title>
+<entry type="method" name="even" return="jQuery">
+  <title>.even()</title>
   <signature>
-    <added>1.4</added>
+    <added>3.5</added>
   </signature>
-  <desc>Reduce the set of matched elements to the final one in the set.</desc>
+  <desc>Reduce the set of matched elements to the even ones in the set, numbered from zero.</desc>
   <longdesc>
-    <p>Given a jQuery object that represents a set of DOM elements, the <code>.last()</code> method constructs a new jQuery object from the last element in that set.</p>
+    <p>Given a jQuery object that represents a set of DOM elements, the <code>.even()</code> method constructs a new jQuery object from the even elements in that set. Counting starts from zero!</p>
     <p>Consider a page with a simple list on it:</p>
     <pre><code>
 &lt;ul&gt;
@@ -19,19 +19,19 @@
     </code></pre>
     <p>We can apply this method to the set of list items:</p>
     <pre><code>
-$( "li" ).last().css( "background-color", "red" );
+$( "li" ).even().css( "background-color", "red" );
     </code></pre>
-    <p>The result of this call is a red background for the final item.</p>
+    <p>The result of this call is a red background for the first, third &amp; 5th items.</p>
   </longdesc>
   <example>
-    <desc>Highlight the last item in a list.</desc>
+    <desc>Highlight the even items in a list.</desc>
     <css><![CDATA[
   .highlight {
     background-color: yellow;
   }
 ]]></css>
     <code><![CDATA[
-$( "ul li" ).last().addClass( "highlight" );
+$( "ul li" ).even().addClass( "highlight" );
 ]]></code>
     <html><![CDATA[
 <ul>
@@ -43,5 +43,5 @@ $( "ul li" ).last().addClass( "highlight" );
 ]]></html>
   </example>
   <category slug="traversing/filtering"/>
-  <category slug="version/1.4"/>
+  <category slug="version/3.5"/>
 </entry>

--- a/entries/filter.xml
+++ b/entries/filter.xml
@@ -42,9 +42,9 @@
     </code></pre>
     <p>We can apply this method to the set of list items:</p>
     <pre><code>
-$( "li" ).filter( ":even" ).css( "background-color", "red" );
+$( "li" ).filter( ":nth-child(2n)" ).css( "background-color", "red" );
     </code></pre>
-    <p>The result of this call is a red background for items 1, 3, and 5, as they match the selector (recall that <code>:even</code> and <code>:odd</code> use 0-based indexing).</p>
+    <p>The result of this call is a red background for items 2, 4, and 6, as they match the selector.</p>
     <h4 id="using-filter-function">Using a Filter Function</h4>
     <p>The second form of this method allows us to filter elements against a function rather than a selector. For each element, if the function returns <code>true</code> (or a "truthy" value), the element will be included in the filtered set; otherwise, it will be excluded. Suppose we have a somewhat more involved HTML snippet:</p>
     <pre><code>

--- a/entries/first-selector.xml
+++ b/entries/first-selector.xml
@@ -7,7 +7,9 @@
   </signature>
   <desc>Selects the first matched DOM element.</desc>
   <longdesc>
-    <p><strong>As of jQuery 3.4</strong>, the <code>:first</code> pseudo-class is deprecated. Remove it from your selectors and filter the results later using <a href="/first/"><code>.first()</code></a>.</p>
+    <div class="warning">
+      <p><strong>As of jQuery 3.4</strong>, the <code>:first</code> pseudo-class is deprecated. Remove it from your selectors and filter the results later using <a href="/first/"><code>.first()</code></a>.</p>
+    </div>
     <p>The <code>:first</code> pseudo-class is equivalent to <code>:eq( 0 )</code>. It could also be written as <code>:lt( 1 )</code>. While this matches only a single element, <a href="/first-child-selector/">:first-child</a> can match more than one: One for each parent.</p>
   </longdesc>
   <note id="jquery-selector-extension" type="additional" data-selector=":first"/>

--- a/entries/first.xml
+++ b/entries/first.xml
@@ -24,21 +24,22 @@ $( "li" ).first().css( "background-color", "red" );
     <p>The result of this call is a red background for the first item.</p>
   </longdesc>
   <example>
-    <desc>Highlight the first span in a paragraph.</desc>
+    <desc>Highlight the first item in a list.</desc>
     <css><![CDATA[
-  .highlight{
-    background-color: yellow
+  .highlight {
+    background-color: yellow;
   }
 ]]></css>
     <code><![CDATA[
-$( "p span" ).first().addClass( "highlight" );
+$( "ul li" ).first().addClass( "highlight" );
 ]]></code>
     <html><![CDATA[
-<p>
-  <span>Look:</span>
-  <span>This is some text in a paragraph.</span>
-  <span>This is a note about it.</span>
-</p>
+<ul>
+  <li>Look:</li>
+  <li>This is some text in a list.</li>
+  <li>This is a note about it.</li>
+  <li>This is another note about it.</li>
+</ul>
 ]]></html>
   </example>
   <category slug="traversing/filtering"/>

--- a/entries/gt-selector.xml
+++ b/entries/gt-selector.xml
@@ -17,7 +17,9 @@
   </signature>
   <desc>Select all elements at an index greater than <code>index</code> within the matched set.</desc>
   <longdesc>
-    <p><strong>As of jQuery 3.4</strong>, the <code>:gt</code> pseudo-class is deprecated. Remove it from your selectors and filter the results later using <a href="/slice/"><code>.slice()</code></a>. For example, <code>:gt(3)</code> can be replaced with a call to <code>.slice( 4 )</code> (the provided index needs to be increased by one).</p>
+    <div class="warning">
+      <p><strong>As of jQuery 3.4</strong>, the <code>:gt</code> pseudo-class is deprecated. Remove it from your selectors and filter the results later using <a href="/slice/"><code>.slice()</code></a>. For example, <code>:gt(3)</code> can be replaced with a call to <code>.slice( 4 )</code> (the provided index needs to be increased by one).</p>
+    </div>
     <p>
       <strong>index-related selectors</strong>
     </p>

--- a/entries/hover.xml
+++ b/entries/hover.xml
@@ -102,10 +102,10 @@ $( selector ).on( "mouseenter mouseleave", handlerInOut );
       <desc>Slide the next sibling LI up or down on hover, and toggle a class.</desc>
       <code><![CDATA[
 $( "li" )
-  .filter( ":odd" )
+  .odd()
     .hide()
   .end()
-  .filter( ":even" )
+  .even()
     .hover(function() {
       $( this )
         .toggleClass( "active" )

--- a/entries/jQuery.ajax.xml
+++ b/entries/jQuery.ajax.xml
@@ -97,7 +97,7 @@ $.ajax({
           <ul>
             <li><code>"xml"</code>: Returns a XML document that can be processed via jQuery.</li>
             <li><code>"html"</code>: Returns HTML as plain text; included script tags are evaluated when inserted in the DOM.</li>
-            <li><code>"script"</code>: Evaluates the response as JavaScript and returns it as plain text. Disables caching by appending a query string parameter, <code>_=[TIMESTAMP]</code>, to the URL unless the <code>cache</code> option is set to <code>true</code>. <strong>Note:</strong> This will turn POSTs into GETs for remote-domain requests.</li>
+            <li><code>"script"</code>: Evaluates the response as JavaScript and returns it as plain text. Disables caching by appending a query string parameter, <code>_=[TIMESTAMP]</code>, to the URL unless the <code>cache</code> option is set to <code>true</code>. <strong>Note:</strong> This will turn POSTs into GETs for remote-domain requests. Prior to jQuery 3.5.0, unsuccessful HTTP responses with a script <code>Content-Type</code> were still executed.</li>
             <li><code>"json"</code>: Evaluates the response as JSON and returns a JavaScript object. Cross-domain <code>"json"</code> requests that have a callback placeholder, e.g. <code>?callback=?</code>, are performed using <a href="https://bob.ippoli.to/archives/2005/12/05/remote-json-jsonp/">JSONP</a> unless the request includes <code>jsonp: false</code> in its request options. The JSON data is parsed in a strict manner; any malformed JSON is rejected and a parse error is thrown. As of jQuery 1.9, an empty response is also rejected; the server should return a response of <code>null</code> or <code>{}</code> instead. (See <a href="https://json.org/">json.org</a> for more information on proper JSON formatting.)</li>
             <li><code>"jsonp"</code>: Loads in a JSON block using <a href="https://bob.ippoli.to/archives/2005/12/05/remote-json-jsonp/">JSONP</a>. Adds an extra <code>"?callback=?"</code> to the end of your URL to specify the callback. Disables caching by appending a query string parameter, <code>"_=[TIMESTAMP]"</code>, to the URL unless the <code>cache</code> option is set to <code>true</code>.</li>
             <li><code>"text"</code>: A plain text string.</li>
@@ -457,4 +457,5 @@ $.ajax({
   <category slug="version/1.0"/>
   <category slug="version/1.5"/>
   <category slug="version/1.5.1"/>
+  <category slug="version/3.5"/>
 </entry>

--- a/entries/jQuery.extend.xml
+++ b/entries/jQuery.extend.xml
@@ -35,6 +35,7 @@
     <p>Keep in mind that the target object (first argument) will be modified, and will also be returned from <code>$.extend()</code>. If, however, you want to preserve both of the original objects, you can do so by passing an empty object as the target:</p>
     <pre><code>var object = $.extend({}, object1, object2);</code></pre>
     <p>The merge performed by <code>$.extend()</code> is not recursive by default; if a property of the first object is itself an object or array, it will be completely overwritten by a property with the same key in the second or subsequent object. The values are not merged. This can be seen in the example below by examining the value of banana. However, by passing <code>true</code> for the first function argument, objects will be recursively merged.</p>
+    <p><strong>Warning</strong>: Versions prior to 3.4 had a security issue where calling <code>jQuery.extend(true, {}, object)</code> on an unsanitized object containing a <code>__proto__</code> property would extend <code>Object.prototype</code>.</p>
     <p><strong>Warning</strong>: Passing <code>false</code> for the first argument is not supported.</p>
     <p>Undefined properties are not copied. However, properties inherited from the object's prototype <em>will</em> be copied over. Properties that are an object constructed via <code>new MyCustomObject(args)</code>, or built-in JavaScript types such as Date or RegExp, are not re-constructed and will appear as plain Objects in the resulting object or array.</p>
     <p>On a <code>deep</code> extend, Object and Array are extended, but object wrappers on primitive types such as String, Boolean, and Number are not. Deep-extending a cyclical data structure will result in an error.</p>
@@ -106,4 +107,5 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
   </example>
   <category slug="utilities"/>
   <category slug="version/1.0"/>
+  <category slug="version/3.4"/>
 </entry>

--- a/entries/jQuery.get.xml
+++ b/entries/jQuery.get.xml
@@ -22,7 +22,7 @@
     </argument>
   </signature>
   <signature>
-    <added>1.12/2.2</added>
+    <added>1.12-and-2.2</added>
     <argument name="settings" type="PlainObject" optional="false">
       <desc>A set of key/value pairs that configure the Ajax request. All properties except for <code>url</code> are optional. A default can be set for any option with <a href="/jQuery.ajaxSetup/">$.ajaxSetup()</a>. See <a href="/jquery.ajax/#jQuery-ajax-settings">jQuery.ajax( settings )</a> for a complete list of all settings. The type option will automatically be set to <code>GET</code>.</desc>
     </argument>
@@ -128,4 +128,5 @@ $.get( "test.php", function( data ) {
   <category slug="ajax/shorthand-methods"/>
   <category slug="version/1.0"/>
   <category slug="version/1.5"/>
+  <category slug="version/1.12-and-2.2"/>
 </entry>

--- a/entries/jQuery.getScript.xml
+++ b/entries/jQuery.getScript.xml
@@ -56,6 +56,7 @@ $( "div.log" ).ajaxError(function( e, jqxhr, settings, exception ) {
   }
 });
     </code></pre>
+    <p>Prior to jQuery 3.5.0, unsuccessful HTTP responses with a script <code>Content-Type</code> were still executed.</p>
     <h4 id="caching-requests">Caching Responses</h4>
     <p>By default, <code>$.getScript()</code> sets the cache setting to <code>false</code>. This appends a timestamped query parameter to the request URL to ensure that the browser downloads the script each time it is requested. You can override this feature by setting the cache property globally using <a href="/jquery.ajaxsetup/"><code>$.ajaxSetup()</code></a>: </p>
     <pre><code>
@@ -125,4 +126,5 @@ $.getScript( url, function() {
   <category slug="ajax/shorthand-methods"/>
   <category slug="version/1.0"/>
   <category slug="version/1.5"/>
+  <category slug="version/3.5"/>
 </entry>

--- a/entries/jQuery.holdReady.xml
+++ b/entries/jQuery.holdReady.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="jQuery.holdReady" return="undefined">
+<entry type="method" name="jQuery.holdReady" return="undefined" deprecated="3.2">
   <title>jQuery.holdReady()</title>
   <desc>Holds or releases the execution of jQuery's ready event.</desc>
   <signature>
@@ -9,6 +9,16 @@
     </argument>
   </signature>
   <longdesc>
+    <div class="warning">
+      <p>Note: This API has been deprecated in jQuery 3.2. Instead of relying on this global switch, it's better to put explicitly wait for required code. If you need to wait both for the ready state &amp; for a custom promise, use the following pattern:</p>
+      <code><![CDATA[$.when( $.ready, customPromise )
+  .then( function() {
+    // main code
+  } )
+  .catch( function( error ) {
+    // handle errors
+  } )]]></code>
+    </div>
     <p>The <code>$.holdReady()</code> method allows the caller to delay jQuery's ready event. This <em>advanced feature</em> would typically be used by dynamic script loaders that want to load additional JavaScript such as jQuery plugins before allowing the ready event to occur, even though the DOM may be ready. This method must be called early in the document, such as in the <code>&lt;head&gt;</code> immediately after the jQuery script tag. Calling this method after the ready event has already fired will have no effect. </p>
     <p>To delay the ready event, first call <code>$.holdReady( true )</code>. When the ready event should be released to execute, call <code>$.holdReady( false )</code>. Note that multiple holds can be put on the ready event, one for each <code>$.holdReady( true )</code> call. The ready event will not actually fire until all holds have been released with a corresponding number of <code>$.holdReady( false )</code> calls <em>and</em> the normal document ready conditions are met. (See <a href="/ready/"><code>ready</code></a> for more information.)</p>
   </longdesc>
@@ -25,4 +35,5 @@ $.getScript( "myplugin.js", function() {
   <category slug="properties/global-jquery-object-properties"/>
   <category slug="events/document-loading"/>
   <category slug="version/1.6"/>
+  <category slug="deprecated/deprecated-3.2"/>
 </entry>

--- a/entries/jQuery.htmlPrefilter.xml
+++ b/entries/jQuery.htmlPrefilter.xml
@@ -3,75 +3,15 @@
   <title>jQuery.htmlPrefilter()</title>
   <desc>Modify and filter HTML strings passed through <a href="/category/manipulation/">jQuery manipulation methods</a>.</desc>
   <signature>
-    <added>1.12/2.2</added>
+    <added>1.12-and-2.2</added>
     <argument name="html" type="String">
       <desc>The HTML string on which to operate.</desc>
     </argument>
   </signature>
   <longdesc>
-    <p>This method rarely needs to be called directly. Instead, use it as an entry point to modify existing <a href="/category/manipulation/">jQuery manipulation methods</a>. For instance, to remove all <code>&lt;del&gt;</code> tags from incoming HTML strings, do this:</p>
-    <pre><code>
-var htmlPrefilter = $.htmlPrefilter,
-  rdel = /&lt;(del)(?=[\s&gt;])[\w\W]*?&lt;\/\1\s*&gt;/gi;
-
-$.htmlPrefilter = function( html ) {
-  return htmlPrefilter.call( this, html ).replace( rdel, "" );
-};
-    </code></pre>
-    <p>This function can also be overwritten in order to bypass certain edge case issues. The default <code>htmlPrefilter</code> function in jQuery will greedily ensure that all tags are XHTML-compliant. This includes anything that looks like an HTML tag, but is actually within a string (e.g. <pre>&lt;a title="&lt;div /&gt;"&gt;&lt;&gt;</pre>). The <code>jQuery.htmlPrefilter()</code> function can be used to bypass this:</p>
-    <pre><code>
-$.htmlPrefilter = function( html ) {
-  // Return HTML strings unchanged
-  return html;
-};
-    </code></pre>
-    <p>However, while the above fix is short and simple, it puts the burden on you to ensure XHTML-compliant tags in any HTML strings. A more thorough fix for this issue would be this:</p>
-    <pre><code>
-var panything = "[\\w\\W]*?",
-
-  // Whitespace
-  // https://html.spec.whatwg.org/multipage/infrastructure.html#space-character
-  pspace = "[\\x20\\t\\r\\n\\f]",
-
-  // End of tag name (whitespace or greater-than)
-  pnameEnd = pspace.replace( "]", "&gt;]" ),
-
-  // Tag name (a leading letter, then almost anything)
-  // https://html.spec.whatwg.org/multipage/syntax.html#tag-open-state
-  // https://html.spec.whatwg.org/multipage/syntax.html#tag-name-state
-  pname = "[a-z]" + pnameEnd.replace( "[", "[^/\\0" ) + "*",
-
-  // Void element (end tag prohibited)
-  // https://html.spec.whatwg.org/multipage/syntax.html#void-elements
-  pvoidName = "(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|" +
-    "source|track|wbr)(?=" + pnameEnd + ")",
-
-  // Attributes (double-quoted value, single-quoted value, unquoted value, or no value)
-  // https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
-  pattrs = "(?:" + pspace + "+[^\\0-\\x20\\x7f-\\x9f=\"'/&gt;]+(?:" + pspace + "*=" + pspace +
-    "*(?:\"" + panything + "\"|'" + panything + "'|" +
-    pnameEnd.replace( "[", "[^" ) + "*(?!/)" +
-    ")|))*" + pspace + "*",
-
-  // Trailing content of a close tag
-  pcloseTail = "(?:" + pspace + panything + "|)",
-
-  rspecialHtml = new RegExp(
-    // Non-void element that self-closes: $1–$5
-    "(&lt;)(?!" + pvoidName + ")(" + pname + ")(" + pattrs + ")(\\/)(&gt;)|" +
-      // No-innerHTML container (element, comment, or CDATA): $6
-      "(&lt;(script|style|textarea)" + pattrs + "&gt;" + panything + "&lt;\\/\\7" + pcloseTail + "&gt;|" +
-      "&lt;!--" + panything + "--)",
-    "gi"
-  ),
-
-  // "&lt;"; element name; attributes; "&gt;"; "&lt;"; "/"; element name; "&gt;"; no-innerHTML container
-  pspecialReplacement = "$1$2$3$5$1$4$2$5$6";
-
-$.htmlPrefilter = function( html ) {
-  return ( html + "" ).replace( rspecialHtml, pspecialReplacement );
-};
-    </code></pre>
+    <p>This method rarely needs to be called directly. Instead, use it as an entry point to modify existing <a href="/category/manipulation/">jQuery manipulation methods</a>. jQuery calls this method on input HTML before processing it further: it accepts an HTML string &amp; should return a HTML string as well.</p>
+    <p>This function can also be overwritten in order to bypass certain edge case issues. The default <code>htmlPrefilter</code> function in jQuery leaves input unmodified since 3.5.0. Older versions would greedily ensure that all tags were XHTML-compliant. This included anything that looked like an HTML tag, but was actually within a string (e.g. <code>&lt;a title="&lt;div /&gt;"&gt;&lt;&gt;</code>), leading to potential security issues. For more information, see the <a href="https://jquery.com/upgrade-guide/3.5/">jQuery Core 3.5 Upgrade guide</a>.</p>
   </longdesc>
   <category slug="manipulation"/>
+  <category slug="version/3.5"/>
 </entry>

--- a/entries/jQuery.isArray.xml
+++ b/entries/jQuery.isArray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="jQuery.isArray" return="boolean">
+<entry type="method" name="jQuery.isArray" return="boolean" deprecated="3.2">
   <title>jQuery.isArray()</title>
   <signature>
     <added>1.3</added>
@@ -9,6 +9,9 @@
   </signature>
   <desc>Determine whether the argument is an array.</desc>
   <longdesc>
+    <div class="warning">
+      <p>Note: This API has been deprecated in jQuery 3.2; please use the native <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray"><code>Array.isArray</code></a> method instead.</p>
+    </div>
     <p><code>$.isArray()</code> returns a Boolean indicating whether the object is a JavaScript array (not an array-like object, such as a jQuery object).</p>
   </longdesc>
   <example>
@@ -22,4 +25,5 @@ Is [] an Array? <b></b>
   </example>
   <category slug="utilities"/>
   <category slug="version/1.3"/>
+  <category slug="deprecated/deprecated-3.2"/>
 </entry>

--- a/entries/jQuery.isFunction.xml
+++ b/entries/jQuery.isFunction.xml
@@ -9,7 +9,9 @@
   </signature>
   <desc>Determines if its argument is callable as a function.</desc>
   <longdesc>
-    <p>As of jQuery 3.3, <code>jQuery.isFunction()</code> has been deprecated. In most cases, its use can be replaced by <code>typeof x === "function"</code>.</p>
+    <div class="warning">
+      <p>As of jQuery 3.3, <code>jQuery.isFunction()</code> has been deprecated. In most cases, its use can be replaced by <code>typeof x === "function"</code>.</p>
+    </div>
     <p><strong>Note:</strong> As of jQuery 1.3, functions provided by the browser like <code>alert()</code> and DOM element methods like <code>getAttribute()</code> are not guaranteed to be detected as functions in browsers such as Internet Explorer.</p>
   </longdesc>
   <example>

--- a/entries/jQuery.isNumeric.xml
+++ b/entries/jQuery.isNumeric.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="jQuery.isNumeric" return="Boolean">
+<entry type="method" name="jQuery.isNumeric" return="Boolean" deprecated="3.3">
   <title>jQuery.isNumeric()</title>
   <desc>Determines whether its argument represents a JavaScript number.</desc>
   <signature>
@@ -9,6 +9,9 @@
     </argument>
   </signature>
   <longdesc>
+    <div class="warning">
+      <p>Note: This API has been deprecated in jQuery 3.3.</p>
+    </div>
     <p>The <code>$.isNumeric()</code> method checks whether its argument represents a numeric value. If so, it returns <code>true</code>. Otherwise it returns <code>false</code>. The argument can be of any type.</p>
     <p>As of jQuery 3.0 <code>$.isNumeric()</code> returns <code>true</code> only if the argument is of type <a href="/Types/#Number"><code>number</code></a>, or if it's of type <code>string</code> and it can be coerced into finite numbers. In all other cases, it returns <code>false</code>.</p>
   </longdesc>
@@ -39,4 +42,5 @@ $.isNumeric( undefined )
   </example>
   <category slug="utilities"/>
   <category slug="version/1.7"/>
+  <category slug="deprecated/deprecated-3.3"/>
 </entry>

--- a/entries/jQuery.isWindow.xml
+++ b/entries/jQuery.isWindow.xml
@@ -9,6 +9,12 @@
   </signature>
   <desc>Determine whether the argument is a window.</desc>
   <longdesc>
+    <div class="warning">
+      <p>Note: This API has been deprecated in jQuery 3.3; if you need this function, reimplement it by yourself:</p>
+      <code><![CDATA[function isWindow( obj ) {
+  return obj != null && obj === obj.window;
+}]]></code>
+    </div>
     <p>This is used in a number of places in jQuery to determine if we're operating against a browser window (such as the current window or an iframe).</p>
   </longdesc>
   <example>

--- a/entries/jQuery.now.xml
+++ b/entries/jQuery.now.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0"?>
-<entry type="method" name="jQuery.now" return="Number">
+<entry type="method" name="jQuery.now" return="Number" deprecated="3.3">
   <title>jQuery.now()</title>
   <signature>
     <added>1.4.3</added>
   </signature>
   <desc>Return a number representing the current time.</desc>
   <longdesc>
-    <p>The <code>$.now()</code> method is a shorthand for the number returned by the expression <code>(new Date).getTime()</code>.</p>
+    <div class="warning">
+      <p>Note: This API has been deprecated in jQuery 3.3; please use the native <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now"><code>Date.now()</code></a> method instead.</p>
+    </div>
+    <p>The <code>$.now()</code> method is an alias for <code>Date.now()</code>.</p>
   </longdesc>
   <category slug="utilities"/>
   <category slug="version/1.4.3"/>
+  <category slug="deprecated/deprecated-3.3"/>
 </entry>

--- a/entries/jQuery.post.xml
+++ b/entries/jQuery.post.xml
@@ -22,7 +22,7 @@
     </argument>
   </signature>
   <signature>
-    <added>1.12/2.2</added>
+    <added>1.12-and-2.2</added>
     <argument name="settings" type="PlainObject" optional="false">
       <desc>A set of key/value pairs that configure the Ajax request. All properties except for <code>url</code> are optional. A default can be set for any option with <a href="/jQuery.ajaxSetup/">$.ajaxSetup()</a>. See <a href="/jquery.ajax/#jQuery-ajax-settings">jQuery.ajax( settings )</a> for a complete list of all settings. Type will automatically be set to <code>POST</code>.</desc>
     </argument>
@@ -167,4 +167,5 @@ $( "#searchForm" ).submit(function( event ) {
   <category slug="ajax/shorthand-methods"/>
   <category slug="version/1.0"/>
   <category slug="version/1.5"/>
+  <category slug="version/1.12-and-2.2"/>
 </entry>

--- a/entries/jQuery.proxy.xml
+++ b/entries/jQuery.proxy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="jQuery.proxy" return="Function">
+<entry type="method" name="jQuery.proxy" return="Function" deprecated="3.3">
   <title>jQuery.proxy()</title>
   <signature>
     <added>1.4</added>
@@ -46,6 +46,9 @@
 
   <desc>Takes a function and returns a new one that will always have a particular context.</desc>
   <longdesc>
+    <div class="warning">
+      <p>Note: This API has been deprecated in jQuery 3.3; please use the native <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind"><code>Function.prototype.bind</code></a> method instead.</p>
+    </div>
     <p>This method is most useful for attaching event handlers to an element where the context is pointing back to a different object. Additionally, jQuery makes sure that even if you bind the function returned from <code>jQuery.proxy()</code> it will still unbind the correct function if passed the original.</p>
     <p>Be aware, however, that jQuery's event binding subsystem assigns a unique id to each event handling function in order to track it when it is used to specify the function to be unbound. The function represented by <code>jQuery.proxy()</code> is seen as a single function by the event subsystem, even when it is used to bind different contexts. To avoid unbinding the wrong handler, use a unique event namespace for binding and unbinding (e.g., <code>"click.myproxy1"</code>) rather than specifying the proxied function during unbinding.</p>
     <p><strong>As of jQuery 1.6</strong>, any number of additional arguments may be supplied to <code>$.proxy()</code>, and they will be passed to the function whose context will be changed.</p>
@@ -170,4 +173,5 @@ $( "#test" )
   <category slug="utilities"/>
   <category slug="version/1.4"/>
   <category slug="version/1.6"/>
+  <category slug="deprecated/deprecated-3.3"/>
 </entry>

--- a/entries/jQuery.trim.xml
+++ b/entries/jQuery.trim.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="jQuery.trim" return="String">
+<entry type="method" name="jQuery.trim" return="String" deprecated="3.5">
   <title>jQuery.trim()</title>
   <signature>
     <added>1.0</added>
@@ -9,6 +9,9 @@
   </signature>
   <desc>Remove the whitespace from the beginning and end of a string.</desc>
   <longdesc>
+    <div class="warning">
+      <p>Note: This API has been deprecated in jQuery 3.5; please use the native <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim"><code>String.prototype.trim</code></a> method instead.</p>
+    </div>
     <p>The <code>$.trim()</code> function removes all newlines, spaces (including non-breaking spaces), and tabs from the beginning and end of the supplied string. If these whitespace characters occur in the middle of the string, they are preserved.</p>
   </longdesc>
   <example>
@@ -34,4 +37,5 @@ $.trim("    hello, how are you?    ");
   </example>
   <category slug="utilities"/>
   <category slug="version/1.0"/>
+  <category slug="deprecated/deprecated-3.5"/>
 </entry>

--- a/entries/jQuery.type.xml
+++ b/entries/jQuery.type.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="jQuery.type" return="String">
+<entry type="method" name="jQuery.type" return="String" deprecated="3.3">
   <title>jQuery.type()</title>
   <signature>
     <added>1.4.3</added>
@@ -9,6 +9,9 @@
   </signature>
   <desc>Determine the internal JavaScript [[Class]] of an object.</desc>
   <longdesc>
+    <div class="warning">
+      <p>Note: This API has been deprecated in jQuery 3.3.</p>
+    </div>
     <p>A number of techniques are used to determine the exact return value for an object. The [[Class]] is determined as follows:</p>
     <ul>
       <li>If the object is undefined or null, then "undefined" or "null" is returned accordingly.
@@ -24,16 +27,16 @@
           <li>jQuery.type( true ) === "boolean"</li>
           <li>jQuery.type( new Boolean() ) === "boolean"</li>
           <li>jQuery.type( 3 ) === "number"</li>
-          <li>jQuery.type( new Number(3) ) === "number"</li>
+          <li>jQuery.type( new Number( 3 ) ) === "number"</li>
           <li>jQuery.type( "test" ) === "string"</li>
-          <li>jQuery.type( new String("test") ) === "string"</li>
-          <li>jQuery.type( function(){} ) === "function"</li>
+          <li>jQuery.type( new String( "test" ) ) === "string"</li>
+          <li>jQuery.type( function() {} ) === "function"</li>
           <li>jQuery.type( [] ) === "array"</li>
           <li>jQuery.type( new Array() ) === "array"</li>
           <li>jQuery.type( new Date() ) === "date"</li>
           <li>jQuery.type( new Error() ) === "error" // <strong>as of jQuery 1.9</strong></li>
           <li>jQuery.type( Symbol() ) === "symbol" // <strong>as of jQuery 1.9</strong></li>
-          <li>jQuery.type( Object(Symbol()) ) === "symbol" // <strong>as of jQuery 1.12</strong></li>
+          <li>jQuery.type( Object( Symbol() ) ) === "symbol" // <strong>as of jQuery 1.12</strong></li>
           <li>jQuery.type( /test/ ) === "regexp"</li>
         </ul>
       </li>
@@ -51,4 +54,5 @@ Is it a RegExp? <b></b>
   </example>
   <category slug="utilities"/>
   <category slug="version/1.4.3"/>
+  <category slug="deprecated/deprecated-3.3"/>
 </entry>

--- a/entries/jQuery.uniqueSort.xml
+++ b/entries/jQuery.uniqueSort.xml
@@ -2,7 +2,7 @@
 <entry type="method" name="jQuery.uniqueSort" return="Array">
   <title>jQuery.uniqueSort()</title>
   <signature>
-    <added>1.12-2.2</added>
+    <added>1.12-and-2.2</added>
     <argument name="array" type="Array">
       <desc>The Array of DOM elements.</desc>
     </argument>
@@ -42,5 +42,5 @@ $( "div" ).eq( 2 ).text( "Post-unique there are " + divs.length + " elements." )
 ]]></html>
   </example>
   <category slug="utilities"/>
-  <category slug="version/1.12-2.2"/>
+  <category slug="version/1.12-and-2.2"/>
 </entry>

--- a/entries/last-selector.xml
+++ b/entries/last-selector.xml
@@ -7,7 +7,9 @@
   </signature>
   <desc>Selects the last matched element.</desc>
   <longdesc>
-    <p><strong>As of jQuery 3.4</strong>, the <code>:last</code> pseudo-class is deprecated. Remove it from your selectors and filter the results later using <a href="/last/"><code>.last()</code></a>.</p>
+    <div class="warning">
+      <p><strong>As of jQuery 3.4</strong>, the <code>:last</code> pseudo-class is deprecated. Remove it from your selectors and filter the results later using <a href="/last/"><code>.last()</code></a>.</p>
+    </div>
     <p>Note that <code>:last</code> selects a single element by filtering  the current jQuery collection and matching the last element within it.</p>
   </longdesc>
   <note id="jquery-selector-extension" type="additional" data-selector=":last"/>

--- a/entries/lt-selector.xml
+++ b/entries/lt-selector.xml
@@ -17,7 +17,9 @@
   </signature>
   <desc>Select all elements at an index less than <code>index</code> within the matched set.</desc>
   <longdesc>
-    <p><strong>As of jQuery 3.4</strong>, the <code>:lt</code> pseudo-class is deprecated. Remove it from your selectors and filter the results later using <a href="/slice/"><code>.slice()</code></a>. For example, <code>:lt(3)</code> can be replaced with a call to <code>.slice( 0, 3 )</code>.</p>
+    <div class="warning">
+      <p><strong>As of jQuery 3.4</strong>, the <code>:lt</code> pseudo-class is deprecated. Remove it from your selectors and filter the results later using <a href="/slice/"><code>.slice()</code></a>. For example, <code>:lt(3)</code> can be replaced with a call to <code>.slice( 0, 3 )</code>.</p>
+    </div>
     <p>
       <strong>index-related selectors</strong>
     </p>

--- a/entries/not.xml
+++ b/entries/not.xml
@@ -40,9 +40,9 @@
     </code></pre>
     <p>We can apply this method to the set of list items:</p>
     <pre><code>
-$( "li" ).not( ":even" ).css( "background-color", "red" );
+$( "li" ).not( ":nth-child(2n)" ).css( "background-color", "red" );
     </code></pre>
-    <p>The result of this call is a red background for items 2 and 4, as they do not match the selector (recall that :even and :odd use 0-based indexing).</p>
+    <p>The result of this call is a red background for items 1, 3 and 5, as they do not match the selector.</p>
     <h4>Removing Specific Elements</h4>
     <p>The second version of the <code>.not()</code> method allows us to remove elements from the matched set, assuming we have found those elements previously by some other means. For example, suppose our list had an id applied to one of its items:</p>
     <pre><code>

--- a/entries/nth-child-selector.xml
+++ b/entries/nth-child-selector.xml
@@ -51,12 +51,17 @@ $( "ul li:nth-child(2)" ).append( "<span> - 2nd!</span>" );
 ]]></html>
   </example>
   <example>
-    <desc>This is a playground to see how the selector works with different strings.  Notice that this is different from the :even and :odd which have no regard for parent and just filter the list of elements to every other one.  The :nth-child, however, counts the index of the child to its particular parent.  In any case, it's easier to see than explain so...</desc>
+    <desc>This is a playground to see how the selector works with different strings.  Notice that this is different from the <a href="/even/"><code>even</code></a> and <a href="/odd/"><code>odd</code></a> which have no regard for parent and just filter the list of elements to every other one.  The :nth-child, however, counts the index of the child to its particular parent.  In any case, it's easier to see than explain so...</desc>
     <code><![CDATA[
 $( "button" ).click(function() {
   var str = $( this ).text();
+  var method = $( this ).attr( "data-method" );
   $( "tr" ).css( "background", "white" );
-  $( "tr" + str ).css( "background", "#ff0000" );
+  if ( method ) {
+    $( "tr" )[ method ]().css( "background", "#ff0000" );
+  } else {
+    $( "tr" + str ).css( "background", "#ff0000" );
+  }
   $( "#inner" ).text( str );
 });
 ]]></code>
@@ -94,8 +99,8 @@ $( "button" ).click(function() {
 <div>
   <button>:nth-child(3n+1)</button>
   <button>:nth-child(3n+2)</button>
-  <button>:even</button>
-  <button>:odd</button>
+  <button data-method="even">.even()</button>
+  <button data-method="odd">.odd()</button>
 </div>
 
 <div>

--- a/entries/odd-selector.xml
+++ b/entries/odd-selector.xml
@@ -5,8 +5,11 @@
   <signature>
     <added>1.0</added>
   </signature>
-  <desc>Selects odd elements, zero-indexed.  See also <a href="/even-selector/">even</a>.</desc>
+  <desc>Selects odd elements, zero-indexed.  See also <a href="/even-selector/"><code>:even</code></a>.</desc>
   <longdesc>
+    <div class="warning">
+      <p><strong>As of jQuery 3.4</strong>, the <code>:odd</code> pseudo-class is deprecated. Remove it from your selectors and filter the results later using <a href="/odd/"><code>.odd()</code></a> (available in jQuery 3.5.0 or newer).</p>
+    </div>
     <p>In particular, note that the <em>0-based indexing</em> means that, counter-intuitively, <code>:odd</code> selects the second element, fourth element, and so on within the matched set.</p>
   </longdesc>
   <note id="jquery-selector-extension" type="additional" data-selector=":odd"/>

--- a/entries/odd.xml
+++ b/entries/odd.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
-<entry type="method" name="last" return="jQuery">
-  <title>.last()</title>
+<entry type="method" name="odd" return="jQuery">
+  <title>.odd()</title>
   <signature>
-    <added>1.4</added>
+    <added>3.5</added>
   </signature>
-  <desc>Reduce the set of matched elements to the final one in the set.</desc>
+  <desc>Reduce the set of matched elements to the odd ones in the set, numbered from zero.</desc>
   <longdesc>
-    <p>Given a jQuery object that represents a set of DOM elements, the <code>.last()</code> method constructs a new jQuery object from the last element in that set.</p>
+    <p>Given a jQuery object that represents a set of DOM elements, the <code>.odd()</code> method constructs a new jQuery object from the odd elements in that set. Counting starts from zero!</p>
     <p>Consider a page with a simple list on it:</p>
     <pre><code>
 &lt;ul&gt;
@@ -19,19 +19,19 @@
     </code></pre>
     <p>We can apply this method to the set of list items:</p>
     <pre><code>
-$( "li" ).last().css( "background-color", "red" );
+$( "li" ).odd().css( "background-color", "red" );
     </code></pre>
-    <p>The result of this call is a red background for the final item.</p>
+    <p>The result of this call is a red background for the second &amp; 4th items.</p>
   </longdesc>
   <example>
-    <desc>Highlight the last item in a list.</desc>
+    <desc>Highlight the odd items in a list.</desc>
     <css><![CDATA[
   .highlight {
     background-color: yellow;
   }
 ]]></css>
     <code><![CDATA[
-$( "ul li" ).last().addClass( "highlight" );
+$( "ul li" ).odd().addClass( "highlight" );
 ]]></code>
     <html><![CDATA[
 <ul>
@@ -43,5 +43,5 @@ $( "ul li" ).last().addClass( "highlight" );
 ]]></html>
   </example>
   <category slug="traversing/filtering"/>
-  <category slug="version/1.4"/>
+  <category slug="version/3.5"/>
 </entry>

--- a/entries/removeClass.xml
+++ b/entries/removeClass.xml
@@ -8,17 +8,23 @@
     </argument>
   </signature>
   <signature>
+    <added>3.3</added>
+    <argument name="classNames" type="Array">
+      <desc>An array of classes to be removed from the class attribute of each matched element.</desc>
+    </argument>
+  </signature>
+  <signature>
     <added>1.4</added>
     <argument name="function" type="Function">
       <argument name="index" type="Integer" />
       <argument name="className" type="String" />
       <return type="String" />
-      <desc>A function returning one or more space-separated class names to be removed. Receives the index position of the element in the set and the old class value as arguments.</desc>
+      <desc>A function returning one or more space-separated classes or an array of classes to be removed. Receives the index position of the element in the set and the old class value as arguments.</desc>
     </argument>
   </signature>
   <desc>Remove a single class, multiple classes, or all classes from each element in the set of matched elements.</desc>
   <longdesc>
-    <p>If a class name is included as a parameter, then only that class will be removed from the set of matched elements. If no class names are specified in the parameter, all classes will be removed.</p>
+    <p>If a class name is included as a parameter, then only that class will be removed from the set of matched elements. If no classes are specified in the parameter, all classes will be removed.</p>
     <p>Before jQuery version 1.12/2.2, the <code>.removeClass()</code> method manipulated the <code>className</code> <em>property</em> of the selected elements, not the <code>class</code> <em>attribute</em>. Once the property was changed, it was the browser that updated the attribute accordingly. This means that when the <code>class</code> attribute was updated and the last class name was removed, the browser might have set the attribute's value to an empty string instead of removing the attribute completely. An implication of this behavior was that this method only worked for documents with HTML DOM semantics (e.g., not pure XML documents).</p>
     <p>As of jQuery 1.12/2.2, this behavior is changed to improve the support for XML documents, including SVG. Starting from this version, the <code>class</code> <em>attribute</em> is used instead. So, <code>.removeClass()</code> can be used on XML or SVG documents.</p>
     <p>More than one class may be removed at a time, separated by a space, from the set of matched elements, like so:</p>
@@ -42,7 +48,7 @@ $( "li" ).last().removeClass(function() {
   <example>
     <desc>Remove the class 'blue' from the matched elements.</desc>
     <code><![CDATA[
-$( "p:even" ).removeClass( "blue" );
+$( "p" ).even().removeClass( "blue" );
 ]]></code>
     <css><![CDATA[
   p {
@@ -70,7 +76,35 @@ $( "p:even" ).removeClass( "blue" );
   <example>
     <desc>Remove the class 'blue' and 'under' from the matched elements.</desc>
     <code><![CDATA[
-$( "p:odd" ).removeClass( "blue under" );
+$( "p" ).odd().removeClass( "blue under" );
+]]></code>
+    <css><![CDATA[
+  p {
+    margin: 4px;
+    font-size: 16px;
+    font-weight: bolder;
+  }
+  .blue {
+    color: blue;
+  }
+  .under {
+    text-decoration: underline;
+  }
+  .highlight {
+    background: yellow;
+  }
+]]></css>
+    <html><![CDATA[
+<p class="blue under">Hello</p>
+<p class="blue under highlight">and</p>
+<p class="blue under">then</p>
+<p class="blue under">Goodbye</p>
+]]></html>
+  </example>
+  <example>
+    <desc>Remove the class 'blue' and 'under' from the matched elements (3.3+ syntax).</desc>
+    <code><![CDATA[
+$( "p" ).odd().removeClass( [ "blue", "under" ] );
 ]]></code>
     <css><![CDATA[
   p {
@@ -128,4 +162,6 @@ $( "p" ).eq( 1 ).removeClass();
   <category slug="css"/>
   <category slug="version/1.0"/>
   <category slug="version/1.4"/>
+  <category slug="version/1.12-and-2.2"/>
+  <category slug="version/3.3"/>
 </entry>

--- a/entries/toggleClass.xml
+++ b/entries/toggleClass.xml
@@ -5,16 +5,31 @@
     <signature>
       <added>1.0</added>
       <argument name="className" type="String">
-        <desc>One or more class names (separated by spaces) to be toggled for each element in the matched set.</desc>
+        <desc>One or more classes (separated by spaces) to be toggled for each element in the matched set.</desc>
       </argument>
     </signature>
     <signature>
       <added>1.3</added>
       <argument name="className" type="String">
-        <desc>One or more class names (separated by spaces) to be toggled for each element in the matched set.</desc>
+        <desc>One or more classes (separated by spaces) to be toggled for each element in the matched set.</desc>
       </argument>
       <argument name="state" type="Boolean">
-        <desc>A Boolean (not just truthy/falsy) value to determine whether the class should be added or removed.</desc>
+        <desc>A boolean (not just truthy/falsy) value to determine whether the class should be added or removed.</desc>
+      </argument>
+    </signature>
+    <signature>
+      <added>3.3</added>
+      <argument name="classNames" type="Array">
+        <desc>An array of classes to be toggled for each element in the matched set.</desc>
+      </argument>
+    </signature>
+    <signature>
+      <added>3.3</added>
+      <argument name="classNames" type="Array">
+        <desc>An array of classes to be toggled for each element in the matched set.</desc>
+      </argument>
+      <argument name="state" type="Boolean">
+        <desc>A boolean (not just truthy/falsy) value to determine whether the class should be added or removed.</desc>
       </argument>
     </signature>
     <signature>
@@ -24,7 +39,7 @@
         <argument name="className" type="String" />
         <argument name="state" type="Boolean" />
         <return type="String" />
-        <desc>A function that returns class names to be toggled in the class attribute of each element in the matched set. Receives the index position of the element in the set, the old class value, and the state as arguments.</desc>
+        <desc>A function that returns one or more space-separated classes or an array of classes to be toggled in the class attribute of each element in the matched set. Receives the index position of the element in the set, the old class value, and the state as arguments.</desc>
       </argument>
       <argument name="state" optional="true" type="Boolean">
         <desc>A boolean value to determine whether the class should be added or removed.</desc>
@@ -32,7 +47,7 @@
     </signature>
     <desc>Add or remove one or more classes from each element in the set of matched elements, depending on either the class's presence or the value of the state argument.</desc>
     <longdesc>
-      <p>This method takes one or more class names as its parameter. In the first version, if an element in the matched set of elements already has the class, then it is removed; if an element does not have the class, then it is added. For example, we can apply <code>.toggleClass()</code> to a simple <code>&lt;div&gt;</code>: </p>
+      <p>This method takes one or more classes as its parameter. In the first version, if an element in the matched set of elements already has the class, then it is removed; if an element does not have the class, then it is added. For example, we can apply <code>.toggleClass()</code> to a simple <code>&lt;div&gt;</code>: </p>
       <pre><code>
 &lt;div class="tumble"&gt;Some text.&lt;/div&gt;
       </code></pre>
@@ -55,7 +70,7 @@ if ( addOrRemove ) {
   $( "#foo" ).removeClass( className );
 }
       </code></pre>
-      <p><strong>As of jQuery 1.4</strong>, if no arguments are passed to <code>.toggleClass()</code>, all class names on the element the first time <code>.toggleClass()</code> is called will be toggled. Also as of jQuery 1.4, the class name to be toggled can be determined by passing in a function.</p>
+      <p><strong>As of jQuery 1.4</strong>, if no arguments are passed to <code>.toggleClass()</code>, all classes on the element the first time <code>.toggleClass()</code> is called will be toggled. Also as of jQuery 1.4, the class name to be toggled can be determined by passing in a function.</p>
       <pre><code>
 $( "div.foo" ).toggleClass(function() {
   if ( $( this ).parent().is( ".bar" ) ) {
@@ -197,6 +212,8 @@ $( "a" ).on( "click", function( event ) {
     <category slug="version/1.0"/>
     <category slug="version/1.3"/>
     <category slug="version/1.4"/>
+    <category slug="version/1.12-and-2.2"/>
+    <category slug="version/3.3"/>
   </entry>
   <entry type="method" name="toggleClass" return="jQuery" deprecated="3.0">
     <signature>

--- a/entries2html.xsl
+++ b/entries2html.xsl
@@ -12,7 +12,7 @@
 	&lt;meta charset="utf-8"&gt;
 	&lt;title&gt;<xsl:value-of select="//entry/@name"/> demo&lt;/title&gt;<xsl:if test="css">
 	&lt;style&gt;<xsl:value-of select="css/text()"/>	&lt;/style&gt;</xsl:if>
-	&lt;script src="https://code.jquery.com/jquery-3.4.1.js"&gt;&lt;/script&gt;<xsl:if test="code/@location='head'">
+	&lt;script src="https://code.jquery.com/jquery-3.5.0.js"&gt;&lt;/script&gt;<xsl:if test="code/@location='head'">
 	&lt;script&gt;
 	<xsl:copy-of select="code/text()"/>
 	&lt;/script&gt;


### PR DESCRIPTION
This has many changes but the ones on which I'd focus the most during reviews are:
* New categories for jQuery 3.5 but also older versions
* `even`/`odd` docs, removal of `:even`/`:odd` usage on API pages
* `addClass`/`removeClass`/`toggleClass`: array input signature + examples
* `htmlPrefilter`: rewritten, examples removed. The previous example of a more thorough check still wasn't covering all the cases so I didn't want people to have an impression this can be done securely like that.

Fixes #947
Fixes #949
Fixes #950
Fixes #1142
Ref #970
Ref #972