### PR TITLE
jQuery.globalEval: Document the document parameter

### DIFF
--- a/entries/jQuery.globalEval.xml
+++ b/entries/jQuery.globalEval.xml
@@ -18,6 +18,20 @@
       </property>
     </argument>
   </signature>
+  <signature>
+    <added>3.5.0</added>
+    <argument name="code" type="String">
+      <desc>The JavaScript code to execute.</desc>
+    </argument>
+    <argument name="options" type="PlainObject" optional="true">
+      <property name="nonce" type="string">
+        <desc>The nonce attribute passed to the executed script.</desc>
+      </property>
+    </argument>
+    <argument name="doc" type="Document" optional="true">
+      <desc>A document in which context the code will be evaluated.</desc>
+    </argument>
+  </signature>
   <desc>Execute some JavaScript code globally.</desc>
   <longdesc>
     <p>This method behaves differently from using a normal JavaScript <code>eval()</code> in that it's executed within the global context (which is important for loading external scripts dynamically).</p>

--- a/entries/jQuery.xml
+++ b/entries/jQuery.xml
@@ -155,7 +155,7 @@ $( myForm.elements ).hide();
       <argument name="html" type="htmlString">
         <desc>A string of HTML to create on the fly. Note that this parses HTML, <strong>not</strong> XML.</desc>
       </argument>
-      <argument name="ownerDocument" optional="true" type="document">
+      <argument name="ownerDocument" optional="true" type="Document">
         <desc>A document in which the new elements will be created.</desc>
       </argument>
     </signature>

--- a/pages/Types.html
+++ b/pages/Types.html
@@ -663,6 +663,8 @@ console.log( obj.foo() );
 </p>
 <h2 id="Callbacks">Callbacks Object</h2>
 <p>A multi-purpose object that provides a powerful way to manage callback lists. It supports adding, removing, firing, and disabling callbacks. The Callbacks object is created and returned by the <code>$.Callbacks</code> function and subsequently returned by most of that function's methods. </p>
+<h2 id="Document">Document</h2>
+<p>A document object created by the browser's DOM parser, usually from a string representing HTML or XML.</p>
 <h2 id="XMLDocument">XML Document</h2>
 <p>A document object created by the browser's XML DOM parser, usually from a string representing XML. XML documents have different semantics than HTML documents, but most of the traversing and manipulation methods provided by jQuery will work with them.</p>
 <h2 id="Assert">Assert</h2>


### PR DESCRIPTION
Since jQuery 3.5.0, `jQuery.globalEval` accepts an optional third parameter
accepting a document in which context the code will be evaluated.

This commit also adds the Document type and links it to one of the jQuery
signatures; so far it was using `type="document"` which linked to a non-existent
types section.

Ref jquery/jquery#4601