### PR TITLE
jQuery.extend: Separate the one-argument signature from the multiple-arguments one

### DIFF
--- a/entries/jQuery.extend.xml
+++ b/entries/jQuery.extend.xml
@@ -4,9 +4,9 @@
   <signature>
     <added>1.0</added>
     <argument name="target" type="Object">
-      <desc> An object that will receive the new properties if additional objects are passed in or that will extend the jQuery namespace if it is the sole argument.</desc>
+      <desc> An object that will receive the new properties.</desc>
     </argument>
-    <argument name="object1" type="Object" optional="true">
+    <argument name="object1" type="Object">
       <desc>An object containing additional properties to merge in.</desc>
     </argument>
     <argument name="objectN" optional="true" type="Object">
@@ -26,6 +26,12 @@
     </argument>
     <argument name="objectN" optional="true" type="Object">
       <desc>Additional objects containing properties to merge in.</desc>
+    </argument>
+  </signature>
+  <signature>
+    <added>1.0</added>
+    <argument name="object" type="Object">
+      <desc> An object to merge onto the jQuery namespace.</desc>
     </argument>
   </signature>
   <desc>Merge the contents of two or more objects together into the first object.</desc>


### PR DESCRIPTION
This is done to reduce the confusion as the single-argument signature behaves
completely differently than the other one.

Ref jquery/jquery#4748
Fixes gh-1164