### PR TITLE
addClass:removeClass:toggleClass: Update function signatures

### DIFF
--- a/entries/addClass.xml
+++ b/entries/addClass.xml
@@ -25,7 +25,7 @@
   <signature>
     <added>3.3</added>
     <argument name="function" type="Function">
-      <desc>A function returning one or more space-separated classes or an array of classes to be added to the existing class name(s). Receives the index position of the element in the set and the existing class name(s) as arguments. Within the function, <code>this</code> refers to the current element in the set.</desc>
+      <desc>A function returning one or more space-separated class names or an array of class names to be added to the existing class name(s). Receives the index position of the element in the set and the existing class name(s) as arguments. Within the function, <code>this</code> refers to the current element in the set.</desc>
       <argument name="index" type="Integer" />
       <argument name="currentClassName" type="String" />
       <return type="String"/>

--- a/entries/addClass.xml
+++ b/entries/addClass.xml
@@ -16,6 +16,15 @@
   <signature>
     <added>1.4</added>
     <argument name="function" type="Function">
+      <desc>A function returning one or more space-separated class names to be added to the existing class name(s). Receives the index position of the element in the set and the existing class name(s) as arguments. Within the function, <code>this</code> refers to the current element in the set.</desc>
+      <argument name="index" type="Integer" />
+      <argument name="currentClassName" type="String" />
+      <return type="String"/>
+    </argument>
+  </signature>
+  <signature>
+    <added>3.3</added>
+    <argument name="function" type="Function">
       <desc>A function returning one or more space-separated classes or an array of classes to be added to the existing class name(s). Receives the index position of the element in the set and the existing class name(s) as arguments. Within the function, <code>this</code> refers to the current element in the set.</desc>
       <argument name="index" type="Integer" />
       <argument name="currentClassName" type="String" />

--- a/entries/addClass.xml
+++ b/entries/addClass.xml
@@ -20,6 +20,7 @@
       <argument name="index" type="Integer" />
       <argument name="currentClassName" type="String" />
       <return type="String"/>
+      <return type="Array"/>
     </argument>
   </signature>
   <desc>Adds the specified class(es) to each element in the set of matched elements.</desc>

--- a/entries/removeClass.xml
+++ b/entries/removeClass.xml
@@ -19,6 +19,7 @@
       <argument name="index" type="Integer" />
       <argument name="className" type="String" />
       <return type="String" />
+      <return type="Array" />
       <desc>A function returning one or more space-separated classes or an array of classes to be removed. Receives the index position of the element in the set and the old class value as arguments.</desc>
     </argument>
   </signature>

--- a/entries/removeClass.xml
+++ b/entries/removeClass.xml
@@ -29,7 +29,7 @@
       <argument name="className" type="String" />
       <return type="String" />
       <return type="Array" />
-      <desc>A function returning one or more space-separated classes or an array of classes to be removed. Receives the index position of the element in the set and the old class value as arguments.</desc>
+      <desc>A function returning one or more space-separated class names or an array of class names to be removed. Receives the index position of the element in the set and the old class value as arguments.</desc>
     </argument>
   </signature>
   <desc>Remove a single class, multiple classes, or all classes from each element in the set of matched elements.</desc>

--- a/entries/removeClass.xml
+++ b/entries/removeClass.xml
@@ -19,6 +19,15 @@
       <argument name="index" type="Integer" />
       <argument name="className" type="String" />
       <return type="String" />
+      <desc>A function returning one or more space-separated class names to be removed. Receives the index position of the element in the set and the old class value as arguments.</desc>
+    </argument>
+  </signature>
+  <signature>
+    <added>3.3</added>
+    <argument name="function" type="Function">
+      <argument name="index" type="Integer" />
+      <argument name="className" type="String" />
+      <return type="String" />
       <return type="Array" />
       <desc>A function returning one or more space-separated classes or an array of classes to be removed. Receives the index position of the element in the set and the old class value as arguments.</desc>
     </argument>

--- a/entries/toggleClass.xml
+++ b/entries/toggleClass.xml
@@ -39,6 +39,19 @@
         <argument name="className" type="String" />
         <argument name="state" type="Boolean" />
         <return type="String" />
+        <desc>A function that returns one or more space-separated class names to be toggled in the class attribute of each element in the matched set. Receives the index position of the element in the set, the old class value, and the state as arguments.</desc>
+      </argument>
+      <argument name="state" optional="true" type="Boolean">
+        <desc>A boolean value to determine whether the class should be added or removed.</desc>
+      </argument>
+    </signature>
+    <signature>
+      <added>3.3</added>
+      <argument name="function" type="Function">
+        <argument name="index" type="Integer" />
+        <argument name="className" type="String" />
+        <argument name="state" type="Boolean" />
+        <return type="String" />
         <return type="Array" />
         <desc>A function that returns one or more space-separated classes or an array of classes to be toggled in the class attribute of each element in the matched set. Receives the index position of the element in the set, the old class value, and the state as arguments.</desc>
       </argument>

--- a/entries/toggleClass.xml
+++ b/entries/toggleClass.xml
@@ -39,7 +39,7 @@
         <argument name="className" type="String" />
         <argument name="state" type="Boolean" />
         <return type="String" />
-        <desc>A function that returns one or more space-separated class names to be toggled in the class attribute of each element in the matched set. Receives the index position of the element in the set, the old class value, and the state as arguments.</desc>
+        <desc>A function returning one or more space-separated class names to be toggled in the class attribute of each element in the matched set. Receives the index position of the element in the set, the old class value, and the state as arguments.</desc>
       </argument>
       <argument name="state" optional="true" type="Boolean">
         <desc>A boolean value to determine whether the class should be added or removed.</desc>
@@ -53,7 +53,7 @@
         <argument name="state" type="Boolean" />
         <return type="String" />
         <return type="Array" />
-        <desc>A function that returns one or more space-separated classes or an array of classes to be toggled in the class attribute of each element in the matched set. Receives the index position of the element in the set, the old class value, and the state as arguments.</desc>
+        <desc>A function returning one or more space-separated class names or an array of class names to be toggled in the class attribute of each element in the matched set. Receives the index position of the element in the set, the old class value, and the state as arguments.</desc>
       </argument>
       <argument name="state" optional="true" type="Boolean">
         <desc>A boolean value to determine whether the class should be added or removed.</desc>

--- a/entries/toggleClass.xml
+++ b/entries/toggleClass.xml
@@ -39,6 +39,7 @@
         <argument name="className" type="String" />
         <argument name="state" type="Boolean" />
         <return type="String" />
+        <return type="Array" />
         <desc>A function that returns one or more space-separated classes or an array of classes to be toggled in the class attribute of each element in the matched set. Receives the index position of the element in the set, the old class value, and the state as arguments.</desc>
       </argument>
       <argument name="state" optional="true" type="Boolean">


### PR DESCRIPTION
[From jQuery 3.3.0](https://blog.jquery.com/2018/01/19/jquery-3-3-0-a-fragrant-bouquet-of-deprecations-and-is-that-a-new-feature/), if using a function as a argument for `.addClass`, `.removeClass` and `.toggleClass`, the function is allowed to return a `Array`. However, this is not reflected in the return types.