### PR TITLE
removeClass: Separate the signature with no parameters

### DIFF
--- a/entries/removeClass.xml
+++ b/entries/removeClass.xml
@@ -36,7 +36,6 @@
     </signature>
     <desc>Remove a single class or multiple classes from each element in the set of matched elements.</desc>
     <longdesc>
-      <p>If a class name is included as a parameter, then only that class will be removed from the set of matched elements. If no classes are specified in the parameter, all classes will be removed.</p>
       <p>Before jQuery version 1.12/2.2, the <code>.removeClass()</code> method manipulated the <code>className</code> <em>property</em> of the selected elements, not the <code>class</code> <em>attribute</em>. Once the property was changed, it was the browser that updated the attribute accordingly. This means that when the <code>class</code> attribute was updated and the last class name was removed, the browser might have set the attribute's value to an empty string instead of removing the attribute completely. An implication of this behavior was that this method only worked for documents with HTML DOM semantics (e.g., not pure XML documents).</p>
       <p>As of jQuery 1.12/2.2, this behavior is changed to improve the support for XML documents, including SVG. Starting from this version, the <code>class</code> <em>attribute</em> is used instead. So, <code>.removeClass()</code> can be used on XML or SVG documents.</p>
       <p>More than one class may be removed at a time, separated by a space, from the set of matched elements, like so:</p>

--- a/entries/removeClass.xml
+++ b/entries/removeClass.xml
@@ -1,177 +1,197 @@
 <?xml version="1.0"?>
-<entry type="method" name="removeClass" return="jQuery">
-  <title>.removeClass()</title>
-  <signature>
-    <added>1.0</added>
-    <argument name="className" optional="true" type="String">
-      <desc>One or more space-separated classes to be removed from the class attribute of each matched element.</desc>
-    </argument>
-  </signature>
-  <signature>
-    <added>3.3</added>
-    <argument name="classNames" type="Array">
-      <desc>An array of classes to be removed from the class attribute of each matched element.</desc>
-    </argument>
-  </signature>
-  <signature>
-    <added>1.4</added>
-    <argument name="function" type="Function">
-      <argument name="index" type="Integer" />
-      <argument name="className" type="String" />
-      <return type="String" />
-      <desc>A function returning one or more space-separated class names to be removed. Receives the index position of the element in the set and the old class value as arguments.</desc>
-    </argument>
-  </signature>
-  <signature>
-    <added>3.3</added>
-    <argument name="function" type="Function">
-      <argument name="index" type="Integer" />
-      <argument name="className" type="String" />
-      <return type="String" />
-      <return type="Array" />
-      <desc>A function returning one or more space-separated class names or an array of class names to be removed. Receives the index position of the element in the set and the old class value as arguments.</desc>
-    </argument>
-  </signature>
+<entries>
   <desc>Remove a single class, multiple classes, or all classes from each element in the set of matched elements.</desc>
-  <longdesc>
-    <p>If a class name is included as a parameter, then only that class will be removed from the set of matched elements. If no classes are specified in the parameter, all classes will be removed.</p>
-    <p>Before jQuery version 1.12/2.2, the <code>.removeClass()</code> method manipulated the <code>className</code> <em>property</em> of the selected elements, not the <code>class</code> <em>attribute</em>. Once the property was changed, it was the browser that updated the attribute accordingly. This means that when the <code>class</code> attribute was updated and the last class name was removed, the browser might have set the attribute's value to an empty string instead of removing the attribute completely. An implication of this behavior was that this method only worked for documents with HTML DOM semantics (e.g., not pure XML documents).</p>
-    <p>As of jQuery 1.12/2.2, this behavior is changed to improve the support for XML documents, including SVG. Starting from this version, the <code>class</code> <em>attribute</em> is used instead. So, <code>.removeClass()</code> can be used on XML or SVG documents.</p>
-    <p>More than one class may be removed at a time, separated by a space, from the set of matched elements, like so:</p>
-    <pre><code>
-$( "p" ).removeClass( "myClass yourClass" )
-    </code></pre>
-    <p>This method is often used with <code>.addClass()</code> to switch elements' classes from one to another, like so:</p>
-    <pre><code>
-$( "p" ).removeClass( "myClass noClass" ).addClass( "yourClass" );
-    </code></pre>
-    <p>Here, the <code>myClass</code> and <code>noClass</code> classes are removed from all paragraphs, while <code>yourClass</code> is added.</p>
-    <p>To replace all existing classes with another class, we can use <code>.attr( "class", "newClass" )</code> instead.</p>
-    <p>As of jQuery 1.4, the <code>.removeClass()</code> method allows us to indicate the class to be removed by passing in a function.</p>
-    <pre><code>
-$( "li" ).last().removeClass(function() {
-  return $( this ).prev().attr( "class" );
-});
-    </code></pre>
-    <p>This example removes the class name of the penultimate <code>&lt;li&gt;</code> from the last <code>&lt;li&gt;</code>.</p>
-  </longdesc>
-  <example>
-    <desc>Remove the class 'blue' from the matched elements.</desc>
-    <code><![CDATA[
-$( "p" ).even().removeClass( "blue" );
-]]></code>
-    <css><![CDATA[
-  p {
-    margin: 4px;
-    font-size: 16px;
-    font-weight: bolder;
-  }
-  .blue {
-    color: blue;
-  }
-  .under {
-    text-decoration: underline;
-  }
-  .highlight {
-    background: yellow;
-  }
-]]></css>
-    <html><![CDATA[
-<p class="blue under">Hello</p>
-<p class="blue under highlight">and</p>
-<p class="blue under">then</p>
-<p class="blue under">Goodbye</p>
-]]></html>
-  </example>
-  <example>
-    <desc>Remove the class 'blue' and 'under' from the matched elements.</desc>
-    <code><![CDATA[
-$( "p" ).odd().removeClass( "blue under" );
-]]></code>
-    <css><![CDATA[
-  p {
-    margin: 4px;
-    font-size: 16px;
-    font-weight: bolder;
-  }
-  .blue {
-    color: blue;
-  }
-  .under {
-    text-decoration: underline;
-  }
-  .highlight {
-    background: yellow;
-  }
-]]></css>
-    <html><![CDATA[
-<p class="blue under">Hello</p>
-<p class="blue under highlight">and</p>
-<p class="blue under">then</p>
-<p class="blue under">Goodbye</p>
-]]></html>
-  </example>
-  <example>
-    <desc>Remove the class 'blue' and 'under' from the matched elements (3.3+ syntax).</desc>
-    <code><![CDATA[
-$( "p" ).odd().removeClass( [ "blue", "under" ] );
-]]></code>
-    <css><![CDATA[
-  p {
-    margin: 4px;
-    font-size: 16px;
-    font-weight: bolder;
-  }
-  .blue {
-    color: blue;
-  }
-  .under {
-    text-decoration: underline;
-  }
-  .highlight {
-    background: yellow;
-  }
-]]></css>
-    <html><![CDATA[
-<p class="blue under">Hello</p>
-<p class="blue under highlight">and</p>
-<p class="blue under">then</p>
-<p class="blue under">Goodbye</p>
-]]></html>
-  </example>
-  <example>
-    <desc>Remove all the classes from the matched elements.</desc>
-    <code><![CDATA[
-$( "p" ).eq( 1 ).removeClass();
-]]></code>
-    <css><![CDATA[
-  p {
-    margin: 4px;
-    font-size: 16px;
-    font-weight: bolder;
-  }
-  .blue {
-    color: blue;
-  }
-  .under {
-    text-decoration: underline;
-  }
-  .highlight {
-    background: yellow;
-  }
-]]></css>
-    <html><![CDATA[
-<p class="blue under">Hello</p>
-<p class="blue under highlight">and</p>
-<p class="blue under">then</p>
-<p class="blue under">Goodbye</p>
-]]></html>
-  </example>
-  <category slug="attributes"/>
-  <category slug="manipulation/class-attribute"/>
-  <category slug="css"/>
-  <category slug="version/1.0"/>
-  <category slug="version/1.4"/>
-  <category slug="version/1.12-and-2.2"/>
-  <category slug="version/3.3"/>
-</entry>
+  <entry type="method" name="removeClass" return="jQuery">
+    <title>.removeClass( classes )</title>
+    <signature>
+      <added>1.0</added>
+      <argument name="className" type="String">
+        <desc>One or more space-separated classes to be removed from the class attribute of each matched element.</desc>
+      </argument>
+    </signature>
+    <signature>
+      <added>3.3</added>
+      <argument name="classNames" type="Array">
+        <desc>An array of classes to be removed from the class attribute of each matched element.</desc>
+      </argument>
+    </signature>
+    <signature>
+      <added>1.4</added>
+      <argument name="function" type="Function">
+        <argument name="index" type="Integer" />
+        <argument name="className" type="String" />
+        <return type="String" />
+        <desc>A function returning one or more space-separated class names to be removed. Receives the index position of the element in the set and the old class value as arguments.</desc>
+      </argument>
+    </signature>
+    <signature>
+      <added>3.3</added>
+      <argument name="function" type="Function">
+        <argument name="index" type="Integer" />
+        <argument name="className" type="String" />
+        <return type="String" />
+        <return type="Array" />
+        <desc>A function returning one or more space-separated class names or an array of class names to be removed. Receives the index position of the element in the set and the old class value as arguments.</desc>
+      </argument>
+    </signature>
+    <desc>Remove a single class or multiple classes from each element in the set of matched elements.</desc>
+    <longdesc>
+      <p>If a class name is included as a parameter, then only that class will be removed from the set of matched elements. If no classes are specified in the parameter, all classes will be removed.</p>
+      <p>Before jQuery version 1.12/2.2, the <code>.removeClass()</code> method manipulated the <code>className</code> <em>property</em> of the selected elements, not the <code>class</code> <em>attribute</em>. Once the property was changed, it was the browser that updated the attribute accordingly. This means that when the <code>class</code> attribute was updated and the last class name was removed, the browser might have set the attribute's value to an empty string instead of removing the attribute completely. An implication of this behavior was that this method only worked for documents with HTML DOM semantics (e.g., not pure XML documents).</p>
+      <p>As of jQuery 1.12/2.2, this behavior is changed to improve the support for XML documents, including SVG. Starting from this version, the <code>class</code> <em>attribute</em> is used instead. So, <code>.removeClass()</code> can be used on XML or SVG documents.</p>
+      <p>More than one class may be removed at a time, separated by a space, from the set of matched elements, like so:</p>
+      <pre><code>
+  $( "p" ).removeClass( "myClass yourClass" )
+      </code></pre>
+      <p>This method is often used with <code>.addClass()</code> to switch elements' classes from one to another, like so:</p>
+      <pre><code>
+  $( "p" ).removeClass( "myClass noClass" ).addClass( "yourClass" );
+      </code></pre>
+      <p>Here, the <code>myClass</code> and <code>noClass</code> classes are removed from all paragraphs, while <code>yourClass</code> is added.</p>
+      <p>To replace all existing classes with another class, we can use <code>.attr( "class", "newClass" )</code> instead.</p>
+      <p>As of jQuery 1.4, the <code>.removeClass()</code> method allows us to indicate the class to be removed by passing in a function.</p>
+      <pre><code>
+  $( "li" ).last().removeClass(function() {
+    return $( this ).prev().attr( "class" );
+  });
+      </code></pre>
+      <p>This example removes the class name of the penultimate <code>&lt;li&gt;</code> from the last <code>&lt;li&gt;</code>.</p>
+    </longdesc>
+    <example>
+      <desc>Remove the class 'blue' from the matched elements.</desc>
+      <code><![CDATA[
+  $( "p" ).even().removeClass( "blue" );
+  ]]></code>
+      <css><![CDATA[
+    p {
+      margin: 4px;
+      font-size: 16px;
+      font-weight: bolder;
+    }
+    .blue {
+      color: blue;
+    }
+    .under {
+      text-decoration: underline;
+    }
+    .highlight {
+      background: yellow;
+    }
+  ]]></css>
+      <html><![CDATA[
+  <p class="blue under">Hello</p>
+  <p class="blue under highlight">and</p>
+  <p class="blue under">then</p>
+  <p class="blue under">Goodbye</p>
+  ]]></html>
+    </example>
+    <example>
+      <desc>Remove the class 'blue' and 'under' from the matched elements.</desc>
+      <code><![CDATA[
+  $( "p" ).odd().removeClass( "blue under" );
+  ]]></code>
+      <css><![CDATA[
+    p {
+      margin: 4px;
+      font-size: 16px;
+      font-weight: bolder;
+    }
+    .blue {
+      color: blue;
+    }
+    .under {
+      text-decoration: underline;
+    }
+    .highlight {
+      background: yellow;
+    }
+  ]]></css>
+      <html><![CDATA[
+  <p class="blue under">Hello</p>
+  <p class="blue under highlight">and</p>
+  <p class="blue under">then</p>
+  <p class="blue under">Goodbye</p>
+  ]]></html>
+    </example>
+    <example>
+      <desc>Remove the class 'blue' and 'under' from the matched elements (3.3+ syntax).</desc>
+      <code><![CDATA[
+  $( "p" ).odd().removeClass( [ "blue", "under" ] );
+  ]]></code>
+      <css><![CDATA[
+    p {
+      margin: 4px;
+      font-size: 16px;
+      font-weight: bolder;
+    }
+    .blue {
+      color: blue;
+    }
+    .under {
+      text-decoration: underline;
+    }
+    .highlight {
+      background: yellow;
+    }
+  ]]></css>
+      <html><![CDATA[
+  <p class="blue under">Hello</p>
+  <p class="blue under highlight">and</p>
+  <p class="blue under">then</p>
+  <p class="blue under">Goodbye</p>
+  ]]></html>
+    </example>
+    <category slug="attributes"/>
+    <category slug="manipulation/class-attribute"/>
+    <category slug="css"/>
+    <category slug="version/1.0"/>
+    <category slug="version/1.4"/>
+    <category slug="version/1.12-and-2.2"/>
+    <category slug="version/3.3"/>
+  </entry>
+
+  <entry type="method" name="removeClass" return="jQuery">
+    <title>.removeClass()</title>
+    <signature>
+      <added>1.0</added>
+    </signature>
+    <desc>Remove all classes from each matched element.</desc>
+    <longdesc>
+      <p>Before jQuery version 1.12/2.2, the <code>.removeClass()</code> method manipulated the <code>className</code> <em>property</em> of the selected elements, not the <code>class</code> <em>attribute</em>. Once the property was changed, it was the browser that updated the attribute accordingly. This means that when the <code>class</code> attribute was updated and the last class name was removed, the browser might have set the attribute's value to an empty string instead of removing the attribute completely. An implication of this behavior was that this method only worked for documents with HTML DOM semantics (e.g., not pure XML documents).</p>
+      <p>As of jQuery 1.12/2.2, this behavior is changed to improve the support for XML documents, including SVG. Starting from this version, the <code>class</code> <em>attribute</em> is used instead. So, <code>.removeClass()</code> can be used on XML or SVG documents.</p>
+    </longdesc>
+    <example>
+      <desc>Remove all the classes from the matched elements.</desc>
+      <code><![CDATA[
+  $( "p" ).eq( 1 ).removeClass();
+  ]]></code>
+      <css><![CDATA[
+    p {
+      margin: 4px;
+      font-size: 16px;
+      font-weight: bolder;
+    }
+    .blue {
+      color: blue;
+    }
+    .under {
+      text-decoration: underline;
+    }
+    .highlight {
+      background: yellow;
+    }
+  ]]></css>
+      <html><![CDATA[
+  <p class="blue under">Hello</p>
+  <p class="blue under highlight">and</p>
+  <p class="blue under">then</p>
+  <p class="blue under">Goodbye</p>
+  ]]></html>
+    </example>
+    <category slug="attributes"/>
+    <category slug="manipulation/class-attribute"/>
+    <category slug="css"/>
+    <category slug="version/1.0"/>
+    <category slug="version/1.12-and-2.2"/>
+  </entry>
+</entries>


### PR DESCRIPTION
That signature removes all classes which wasn't that clear from the original
signatures until one read the description.

I recommend reviewing with whitespace changes disabled as the whole file had to be indented.

This has been a point of confusion at my company recently and even I didn't quickly find that it was actually documented as the `removeClass( [ className ] )` signature was describing two essentially different signatures.