### PR TITLE
jQuery.get:jQuery.post: Document issues with `data: null` with 3 params

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Update apt-get cache
+        run: sudo apt-get update
       - name: Install xmllint
         run: sudo apt-get install -y libxml2-utils
       - name: Use Node.js ${{ matrix.node-version }}

--- a/entries/jQuery.get.xml
+++ b/entries/jQuery.get.xml
@@ -15,7 +15,7 @@
       <argument name="data" type="PlainObject" />
       <argument name="textStatus" type="String"/>
       <argument name="jqXHR" type="jqXHR"/>
-      <desc>A callback function that is executed if the request succeeds. Required if <code>dataType</code> is provided, but you can use <code>null</code> or <a href="/jQuery.noop/"><code>jQuery.noop</code></a> as a placeholder.</desc>
+      <desc>A callback function that is executed if the request succeeds. Required if <code>dataType</code> is provided, but you can use <code>null</code> or <a href="/jQuery.noop/"><code>jQuery.noop</code></a> as a placeholder. <strong>NOTE:</strong> In jQuery 3.x and older, when providing a <code>null</code> value for <code>success</code> you also have to provide the <code>data</code> parameter; you can set it to <code>null</code> or <code>undefined</code>.</desc>
     </argument>
     <argument name="dataType" optional="true" type="String">
       <desc>The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).</desc>

--- a/entries/jQuery.post.xml
+++ b/entries/jQuery.post.xml
@@ -15,7 +15,7 @@
       <argument name="data" type="PlainObject" />
       <argument name="textStatus" type="String"/>
       <argument name="jqXHR" type="jqXHR"/>
-      <desc>A callback function that is executed if the request succeeds. Required if <code>dataType</code> is provided, but can be <code>null</code> in that case.</desc>
+      <desc>A callback function that is executed if the request succeeds. Required if <code>dataType</code> is provided, but can be <code>null</code> or <a href="/jQuery.noop/"><code>jQuery.noop</code></a> as a placeholder. <strong>NOTE:</strong> In jQuery 3.x and older, when providing a <code>null</code> value for <code>success</code> you also have to provide the <code>data</code> parameter; you can set it to <code>undefined</code>.</desc>
     </argument>
     <argument name="dataType" optional="true" type="String">
       <desc>The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).</desc>


### PR DESCRIPTION
In jQuery 3.x and older, when providing a `null` value for `success` you also have to provide the `data` parameter; you can set it to `undefined`.

Document this restriction of `jQuery.get` & `jQuery.post`.

Ref jquery/jquery#4989
Ref jquery/jquery#5139