### PR TITLE
jQuery.getScript: Script has been executed before the `success` callback

### DIFF
--- a/entries/jQuery.getScript.xml
+++ b/entries/jQuery.getScript.xml
@@ -27,7 +27,7 @@ $.ajax({
     <h4 id="success-callback">
         Success Callback
       </h4>
-    <p>The callback is fired once the script has been loaded but not necessarily executed.</p>
+    <p>The callback is fired once the script has been loaded and executed.</p>
     <p>Scripts are included and run by referencing the file name:</p>
     <pre><code>
 $.getScript( "ajax/test.js", function( data, textStatus, jqxhr ) {


### PR DESCRIPTION
When executing a callback provided to the optional `success` parameter of [`$.getScript()`](https://api.jquery.com/jquery.getscript/),
we can assume the script has been executed already.

Just like when using `.done()` on the returned jqXHR object.

See issue #1207.