### PR TITLE
jQuery.map:jQuery.uniqueSort: Accept array-like input, fix typos

### DIFF
--- a/entries/jQuery.map.xml
+++ b/entries/jQuery.map.xml
@@ -28,7 +28,7 @@
   <desc>Translate all items in an array or object to new array of items.</desc>
   <longdesc>
     <p>If you wish to process a jQuery object — for example, <code>$('div').map( callback );</code> — use <a href="/map/">.map()</a> instead. </p>
-    <p>The <code>$.map()</code> method applies a function to each item in an array or object and maps the results into a new array. <strong>Prior to jQuery 1.6</strong>, <code>$.map()</code> supports traversing <em>arrays only</em>. <strong>As of jQuery 1.6</strong> it also traverses objects.</p>
+    <p>The <code>$.map()</code> method applies a function to each item in an array or object and maps the results into a new array. <strong>Prior to jQuery 1.6</strong>, <code>$.map()</code> supports traversing <em>arrays and array-like objects only</em>. <strong>As of jQuery 1.6</strong> it also traverses objects.</p>
     <p>Array-like objects &#x2014; those with a <code>.length</code> property <em>and</em> a value on the <code>.length - 1</code> index &#x2014; may be passed to <code>$.map()</code>.</p>
     <pre><code>
 // The following object is array-like.

--- a/entries/jQuery.map.xml
+++ b/entries/jQuery.map.xml
@@ -3,8 +3,8 @@
   <title>jQuery.map()</title>
   <signature>
     <added>1.0</added>
-    <argument name="array" type="Array">
-      <desc>The Array to translate.</desc>
+    <argument name="array" type="ArrayLikeObject">
+      <desc>The Array or an Array-like object to translate.</desc>
     </argument>
     <argument name="callback" type="Function">
       <argument name="elementOfArray" type="Object" />
@@ -16,7 +16,7 @@
   <signature>
     <added>1.6</added>
     <argument name="object" type="Object">
-      <desc>The Object to translate.</desc>
+      <desc>The non-Array-like Object to translate.</desc>
     </argument>
     <argument name="callback" type="Function">
       <argument name="propertyOfObject" type="Object" />
@@ -29,15 +29,12 @@
   <longdesc>
     <p>If you wish to process a jQuery object — for example, <code>$('div').map( callback );</code> — use <a href="/map/">.map()</a> instead. </p>
     <p>The <code>$.map()</code> method applies a function to each item in an array or object and maps the results into a new array. <strong>Prior to jQuery 1.6</strong>, <code>$.map()</code> supports traversing <em>arrays only</em>. <strong>As of jQuery 1.6</strong> it also traverses objects.</p>
-    <p>Array-like objects &#x2014; those with a <code>.length</code> property <em>and</em> a value on the <code>.length - 1</code> index &#x2014; must be converted to actual arrays before being passed to <code>$.map()</code>. The jQuery library provides <a href="/jQuery.makeArray/">$.makeArray()</a> for such conversions.</p>
+    <p>Array-like objects &#x2014; those with a <code>.length</code> property <em>and</em> a value on the <code>.length - 1</code> index &#x2014; may be passed to <code>$.map()</code>.</p>
     <pre><code>
-// The following object masquerades as an array.
+// The following object is array-like.
 var fakeArray = { "length": 2, 0: "Addy", 1: "Subtracty" };
 
-// Therefore, convert it to a real array
-var realArray = $.makeArray( fakeArray )
-
-// Now it can be used reliably with $.map()
+// It can be used reliably with $.map()
 $.map( realArray, function( val, i ) {
   // Do something
 });

--- a/entries/jQuery.uniqueSort.xml
+++ b/entries/jQuery.uniqueSort.xml
@@ -3,28 +3,28 @@
   <title>jQuery.uniqueSort()</title>
   <signature>
     <added>1.12-and-2.2</added>
-    <argument name="array" type="Array">
-      <desc>The Array of DOM elements.</desc>
+    <argument name="array" type="ArrayLikeObject">
+      <desc>The Array or an Array-like object of DOM elements.</desc>
     </argument>
   </signature>
-  <desc>Sorts an array of DOM elements, in place, with the duplicates removed. Note that this only works on arrays of DOM elements, not strings or numbers.</desc>
+  <desc>Sorts an array or an array-like object of DOM elements, in place, with the duplicates removed. Note that this only works on arrays/array-likes of DOM elements, not strings or numbers.</desc>
   <longdesc>
-    <p>The <code>$.uniqueSort()</code> function searches through an array of objects, sorting the array, and removing any duplicate nodes. A node is considered a duplicate if it is the <em>exact same</em> node as one already in the array; two different nodes with identical attributes are not considered to be duplicates. This function only works on plain JavaScript arrays of DOM elements, and is chiefly used internally by jQuery. You probably will never need to use it.</p>
+    <p>The <code>$.uniqueSort()</code> function searches through an array or an array-like object of DOM elements, sorting the array/array-like, and removing any duplicate nodes. A node is considered a duplicate if it is the <em>exact same</em> node as one already in the input; two different nodes with identical attributes are not considered to be duplicates. This function only works on plain JavaScript arrays/array-like objects of DOM elements, and is chiefly used internally by jQuery. You probably will never need to use it.</p>
     <p>Prior to jQuery 3.0, this method was called <code><a href="/jQuery.unique/">jQuery.unique()</a></code>.</p>
     <p>As of jQuery 1.4 the results will always be returned in document order.</p>
   </longdesc>
   <example>
     <desc>Removes any duplicate elements from the array of divs.</desc>
     <code><![CDATA[
-// unique() must take a native array
+// uniqueSort() must take a native array
 var divs = $( "div" ).get();
 
 // Add 3 elements of class dup too (they are divs)
 divs = divs.concat( $( ".dup" ).get() );
-$( "div" ).eq( 1 ).text( "Pre-unique there are " + divs.length + " elements." );
+$( "div" ).eq( 1 ).text( "Pre-uniqueSort there are " + divs.length + " elements." );
 
 divs = jQuery.uniqueSort( divs );
-$( "div" ).eq( 2 ).text( "Post-unique there are " + divs.length + " elements." )
+$( "div" ).eq( 2 ).text( "Post-uniqueSort there are " + divs.length + " elements." )
   .css( "color", "red" );
 ]]></code>
     <css><![CDATA[


### PR DESCRIPTION
_1\. `jQuery.map`: Accept array-like input_

_2\. `jQuery.uniqueSort`: Accept array-like input, fix typos_

Apart from array-like inputs being officially allowed in
`jQuery.uniqueSort` now, in a few places in examples
it used to be referred to as `unique` instead of `uniqueSort`.

----- 

The second one is particularly interesting. For some reason, there's even an example directly claiming `jQuery.uniqueSort` doesn't work on array-likes when its code says something completely opposite - especially that it's sometimes used on jQuery collections. [We even test it on an "Arrayish" class](https://github.com/jquery/jquery/blob/024d87195ac46690023e2b0b308d4406a8a5a27e/test/unit/selector.js#L1957-L1962)!