### PR TITLE
prevAll:uniqueAll: Add uniqueAll, use it in reverse doc order examples

### DIFF
--- a/categories.xml
+++ b/categories.xml
@@ -510,6 +510,15 @@ var files = event.originalEvent.dataTransfer.files;
         <hr/>
       ]]></desc>
     </category>
+    <category name="Version 3.7" slug="3.7">
+      <desc><![CDATA[
+        <p>Aspects of the API that were changed in the corresponding version of jQuery. New <code>.uniqueSort()</code> method performance improvements in manipulation, fixes for <code>.outerWidth( true )</code> &amp; <code>.outerHeight( true )</code> with negative margins, focus fixes.</p>
+        <p>As of this release, jQuery no longer relies on Sizzle.</p>
+        <p>Native events for <code>focus</code> &amp; <code>blur</code> changed in IE to - respectively - <code>focusin</code> and <code>focusout</code>.</p>
+        <p>For more information, see the <a href="https://blog.jquery.com/2023/05/11/jquery-3-7-0-released-staying-in-order/">Release Notes/Changelog</a>.</p>
+        <hr/>
+      ]]></desc>
+    </category>
     <category name="All" slug="all"/>
   </category>
 </categories>

--- a/entries/prevAll.xml
+++ b/entries/prevAll.xml
@@ -50,7 +50,14 @@ $( ".last-item" )
   &lt;div class="last-item"&gt;Last&lt;/div&gt;
 &lt;/div&gt;
     </code></pre>
-    <p>because "Item 2" gets appended to the wrapper div first. To work around the issue, you may use <code><a href="/jQuery.uniqueSort/">$.uniqueSort()</a></code> on the <code>.prevAll()</code> output first:</p>
+    <p>because "Item 2" gets appended to the wrapper div first. To work around the issue, you may use <code><a href="/uniqueSort/">.uniqueSort()</a></code> on the <code>.prevAll()</code> output first:</p>
+    <pre><code>
+$( ".last-item" )
+  .prevAll()
+  .uniqueSort()
+  .wrapAll( "&lt;div class='wrapper'&gt;&lt;/div&gt;" );
+    </code></pre>
+    <p>Note that the <code><a href="/uniqueSort/">.uniqueSort()</a></code> method is only available in jQuery 3.7.0 or newer. In older versions, you will need to use <code><a href="/jQuery.uniqueSort/">$.uniqueSort()</a></code> to achieve a similar effect:</p>
     <pre><code>
 var prevSiblings = $( ".last-item" ).prevAll();
 $.uniqueSort( prevSiblings );
@@ -83,7 +90,7 @@ $( "div" ).last().prevAll().addClass( "before" );
 ]]></html>
   </example>
   <example>
-    <desc>Locate all the divs preceding the last item and wrap them with a div with class <code>wrapper</code> - with or without <code><a href="/jQuery.uniqueSort/">$.uniqueSort()</a></code>.</desc>
+    <desc>Locate all the divs preceding the last item and wrap them with a div with class <code>wrapper</code> - with or without <code><a href="/uniqueSort/">.uniqueSort()</a></code>.</desc>
     <code><![CDATA[
 $( "#container-1" )
   .find( ".item" )
@@ -91,12 +98,12 @@ $( "#container-1" )
   .prevAll()
   .wrapAll( "<div class='wrapper' data-content='No uniqueSort'></div>" );
 
-var prevSiblings = $( "#container-2" )
+$( "#container-2" )
   .find( ".item" )
   .last()
-  .prevAll();
-$.uniqueSort( prevSiblings );
-prevSiblings.wrapAll( "<div class='wrapper' data-content='With uniqueSort'></div>" );
+  .prevAll()
+  .uniqueSort()
+  .wrapAll( "<div class='wrapper' data-content='With uniqueSort'></div>" );
 ]]></code>
     <css><![CDATA[
   body {

--- a/entries/uniqueSort.xml
+++ b/entries/uniqueSort.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0"?>
+<entry type="method" name="uniqueSort" return="jQuery">
+  <title>.uniqueSort()</title>
+  <signature>
+    <added>3.7</added>
+  </signature>
+  <desc>Sorts a jQuery object of DOM elements, in place, with the duplicates removed. Note that this only works on jQuery objects consisting of DOM elements, not strings or numbers.</desc>
+  <longdesc>
+    <p>The <code>.uniqueSort()</code> function searches through a jQuery object, sorting it in document order, and removing any duplicate nodes. A node is considered a duplicate if it is the <em>exact same</em> node as one already in the jQuery object; two different nodes with identical attributes are not considered to be duplicates. This function only works on jQuery objects consisting of DOM elements.</p>
+  </longdesc>
+  <example>
+    <desc>Removes any duplicate elements from the jQuery object of divs.</desc>
+    <code><![CDATA[
+var divs = $( "div" ).get();
+
+// Add 3 elements of class dup too (they are divs)
+divs = divs.concat( $( ".dup" ).get() );
+
+// Create a jQuery object from `divs`.
+var elems = $( divs );
+
+$( "div" )
+  .eq( 1 )
+  .text( "Pre-uniqueSort there are " + elems.length + " elements in the collection." );
+
+elems = elems.uniqueSort(); 
+
+$( "div" )
+  .eq( 2 )
+  .text( "Post-uniqueSort there are " + elems.length + " elements in the collection." )
+  .css( "color", "red" );
+]]></code>
+    <css><![CDATA[
+  div {
+    color: blue;
+  }
+]]></css>
+    <html><![CDATA[
+<div>There are 6 divs in this document.</div>
+<div></div>
+<div class="dup"></div>
+<div class="dup"></div>
+<div class="dup"></div>
+<div></div>
+]]></html>
+  </example>
+  <example>
+    <desc>Locate all the divs preceding the last item and wrap them with a div with class <code>wrapper</code> - with or without <code><a href="/uniqueSort/">.uniqueSort()</a></code>.</desc>
+    <code><![CDATA[
+$( "#container-1" )
+  .find( ".item" )
+  .last()
+  .prevAll()
+  .wrapAll( "<div class='wrapper' data-content='No uniqueSort'></div>" );
+
+$( "#container-2" )
+  .find( ".item" )
+  .last()
+  .prevAll()
+  .uniqueSort()
+  .wrapAll( "<div class='wrapper' data-content='With uniqueSort'></div>" );
+]]></code>
+    <css><![CDATA[
+  body {
+    display: flex;
+  }
+  .container {
+    display: flex;
+    margin: 10px 50px 10px 10px;
+  }
+  .wrapper {
+    position: relative;
+    display: flex;
+    padding: 30px 10px 10px 10px;
+    background: #def;
+    border: 2px solid black;
+  }
+  .wrapper::before {
+    content: attr(data-content);
+    position: absolute;
+    top: 15px;
+    left: 15px;
+  }
+  .item {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 70px;
+    height: 70px;
+    background: #abc;
+    border: 2px solid black;
+    margin: 10px;
+    font-size: 50px;
+  }
+]]></css>
+    <html><![CDATA[
+<div class="container" id="container-1">
+  <div class="item">1</div>
+  <div class="item">2</div>
+  <div class="item">3</div>
+</div>
+
+<div class="container" id="container-2">
+  <div class="item">1</div>
+  <div class="item">2</div>
+  <div class="item">3</div>
+</div>
+]]></html>
+  </example>
+  <category slug="utilities"/>
+  <category slug="version/3.7"/>
+</entry>

--- a/entries2html.xsl
+++ b/entries2html.xsl
@@ -12,7 +12,7 @@
 	&lt;meta charset="utf-8"&gt;
 	&lt;title&gt;<xsl:value-of select="//entry/@name"/> demo&lt;/title&gt;<xsl:if test="css">
 	&lt;style&gt;<xsl:value-of select="css/text()"/>	&lt;/style&gt;</xsl:if>
-	&lt;script src="https://code.jquery.com/jquery-3.6.3.js"&gt;&lt;/script&gt;<xsl:if test="code/@location='head'">
+	&lt;script src="https://code.jquery.com/jquery-3.7.0.js"&gt;&lt;/script&gt;<xsl:if test="code/@location='head'">
 	&lt;script&gt;
 	<xsl:copy-of select="code/text()"/>
 	&lt;/script&gt;


### PR DESCRIPTION
# Description

`.prevAll()` returns elements in the reverse document order. This
can pose issues when used with APIs like `.append()` or `.wrapAll()`.
Document how to deal with the issue with help from `jQuery.uniqueSort()`.

Ref gh-1215
Ref jquery/jquery#5149

This is another version of #1215, meant to be merged after jQuery 3.7.0 gets released.

This PR includes a stub for the `3.7` category and changes the jQuery version used in examples to the `3.x-git` one. This needs to be changed to the real `3.7.0` one after that version gets released. Those two issues need to be addressed before this PR is moved out of the draft status. However, other than that, the PR is ready for reviews.

# Screenshots

## `.prevAll()`

Screenshots of the `.prevAll()` page changes from this PR: 
1. A note at the end of the main description (just before examples): <img width="748" alt="Screen Shot 2022-12-19 at 15 41 26" src="https://user-images.githubusercontent.com/1758366/208453117-b0b65b2a-25a3-4c81-8932-7f33d6438f88.png">
2. The last example: <img width="765" alt="Screen Shot 2022-12-19 at 15 41 55" src="https://user-images.githubusercontent.com/1758366/208453182-b80e8b08-6a3a-4ea3-8dea-7958c3187479.png"> <img width="780" alt="Screen Shot 2022-12-19 at 15 42 10" src="https://user-images.githubusercontent.com/1758366/208453200-8b943a58-8327-4c02-9081-cce7d2e4b986.png">

## `.uniqueSort()`

Screenshots of the new `.uniqueSort()` page (there's also a second example at the end that's a copy of the `.prevAll()` one:
<img width="802" alt="Screen Shot 2022-12-19 at 16 55 02" src="https://user-images.githubusercontent.com/1758366/208467169-231c208c-8689-4f31-a806-384fdb5b9641.png">
<img width="781" alt="Screen Shot 2022-12-19 at 16 55 16" src="https://user-images.githubusercontent.com/1758366/208467179-4a1d5f92-55fc-45bd-bbcb-533da896afc5.png">