### PR TITLE
contains-selector: Mark :contains() as a jQuery extension

### DIFF
--- a/entries/contains-selector.xml
+++ b/entries/contains-selector.xml
@@ -25,5 +25,6 @@ $( "div:contains('John')" ).css( "text-decoration", "underline" );
 ]]></html>
   </example>
   <category slug="selectors/content-filter-selector"/>
+  <category slug="selectors/jquery-selector-extensions"/>
   <category slug="version/1.1.4"/>
 </entry>


### PR DESCRIPTION
For some reason, the relevant category was missing despite `:contains()` definitely not being a standard pseudo.