### PR TITLE
All: Add missing jQuery versions to categories, update entries

### DIFF
--- a/categories.xml
+++ b/categories.xml
@@ -439,11 +439,24 @@ var files = event.originalEvent.dataTransfer.files;
         <hr/>
       ]]></desc>
     </category>
+    <category name="Version 1.10 &amp; 2.0" slug="1.10-and-2.0">
+      <desc><![CDATA[
+        <p>Aspects of the API that were changed in the corresponding versions of jQuery. Changes in jQuery 1.10 and 2.0 include a new `wrap` module, relaxing HTML parsing, and aligning the 1.x &amp; 2.x lines.</p>
+        <p>For more information, see the <a href="https://blog.jquery.com/2013/04/18/jquery-2-0-released/">2.0 Release Notes/Changelog</a> and <a href="https://blog.jquery.com/2013/05/24/jquery-1-10-0-and-2-0-1-released/">1.10.0/2.0.1 Release Notes/Changelog</a>.</p>
+        <hr/>
+      ]]></desc>
+    </category>
+    <category name="Version 1.11 &amp; 2.1" slug="1.11-and-2.1">
+      <desc><![CDATA[
+        <p>Aspects of the API that were changed in the corresponding versions of jQuery. Changes in jQuery 1.11 and 2.1 include lower startup overhead &amp; fewer forced layouts; jQuery is now authored via AMD and published to npm &amp; bower under the name <code>jquery</code>.</p>
+        <p>For more information, see the <a href="https://blog.jquery.com/2014/01/24/jquery-1-11-and-2-1-released/">Release Notes/Changelog</a>.</p>
+        <hr/>
+      ]]></desc>
+    </category>
     <category name="Version 1.12 &amp; 2.2" slug="1.12-and-2.2">
       <desc><![CDATA[
-        <p>Aspects of the API that were changed in the corresponding versions of jQuery. Changes in jQuery 1.12 and 2.2 includes performance improvements of the selector engine, manipulation of class names for SVG elements, support for the Symbol type and iterators added in ES2015, and a new hook has been added for filtering HTML. A <a href="https://github.com/jquery/jquery-migrate">jQuery Migrate Plugin</a> was offered to help developers with a transitional upgrade path.
-        </p>
-        <p>For more information, see the <a href="https://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/">Release Notes/Changelog</a></p>
+        <p>Aspects of the API that were changed in the corresponding versions of jQuery. Changes in jQuery 1.12 and 2.2 include performance improvements of the selector engine, manipulation of class names for SVG elements, support for the Symbol type and iterators added in ES2015, and a new hook has been added for filtering HTML.</p>
+        <p>For more information, see the <a href="https://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/">Release Notes/Changelog</a>.</p>
         <hr/>
       ]]></desc>
     </category>
@@ -451,42 +464,49 @@ var files = event.originalEvent.dataTransfer.files;
       <desc><![CDATA[
         <p>Aspects of the API that were changed in the corresponding version of jQuery. Changes in jQuery 3.0 dealt primarily with deferreds, data, show/hide and removal of some deprecated APIs. A <a href="https://github.com/jquery/jquery-migrate">jQuery Migrate Plugin</a> was offered to help developers with a transitional upgrade path.
         </p>
-        <p>For more information, see the <a href="https://jquery.com/upgrade-guide/3.0/">jQuery Core 3.0 Upgrade guide</a> and the <a href="https://blog.jquery.com/2016/06/09/jquery-3-0-final-released/">Release Notes/Changelog</a></p>
+        <p>For more information, see the <a href="https://jquery.com/upgrade-guide/3.0/">jQuery Core 3.0 Upgrade guide</a> and the <a href="https://blog.jquery.com/2016/06/09/jquery-3-0-final-released/">Release Notes/Changelog</a>.</p>
         <hr/>
       ]]></desc>
     </category>
     <category name="Version 3.1" slug="3.1">
       <desc><![CDATA[
         <p>Aspects of the API that were changed in the corresponding version of jQuery. Version 3.1 added the <a href="/jQuery.readyException">jQuery.readyException</a> API.</p>
-        <p>For more information, see the <a href="https://blog.jquery.com/2016/07/07/jquery-3-1-0-released-no-more-silent-errors/">Release Notes/Changelog</a></p>
+        <p>For more information, see the <a href="https://blog.jquery.com/2016/07/07/jquery-3-1-0-released-no-more-silent-errors/">Release Notes/Changelog</a>.</p>
         <hr/>
       ]]></desc>
     </category>
     <category name="Version 3.2" slug="3.2">
       <desc><![CDATA[
         <p>Aspects of the API that were changed in the corresponding version of jQuery. Version 3.2 added support for custom CSS properties, made <code>.contents()</code> work on the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template"><code>&lt;template&gt;</code> element</a> &amp; made <code>.width()</code> &amp; <code>.height()</code> ignore CSS transforms. A few APIs were deprecated. The deprecated module was added back to the slim build.</p>
-        <p>For more information, see the <a href="https://blog.jquery.com/2017/03/16/jquery-3-2-0-is-out/">Release Notes/Changelog</a></p>
+        <p>For more information, see the <a href="https://blog.jquery.com/2017/03/16/jquery-3-2-0-is-out/">Release Notes/Changelog</a>.</p>
         <hr/>
       ]]></desc>
     </category>
     <category name="Version 3.3" slug="3.3">
       <desc><![CDATA[
         <p>Aspects of the API that were changed in the corresponding version of jQuery. <code>.addClass()</code>, <code>.removeClass()</code> &amp; <code>.toggleClass()</code> now work on arrays of classes; a few APIs were deprecated.</p>
-        <p>For more information, see the <a href="https://blog.jquery.com/2018/01/19/jquery-3-3-0-a-fragrant-bouquet-of-deprecations-and-is-that-a-new-feature/">Release Notes/Changelog</a></p>
+        <p>For more information, see the <a href="https://blog.jquery.com/2018/01/19/jquery-3-3-0-a-fragrant-bouquet-of-deprecations-and-is-that-a-new-feature/">Release Notes/Changelog</a>.</p>
         <hr/>
       ]]></desc>
     </category>
     <category name="Version 3.4" slug="3.4">
       <desc><![CDATA[
         <p>Aspects of the API that were changed in the corresponding version of jQuery. <code>nonce</code> &amp; <code>nomodule</code> attributes are now preserved during script manipulation, layout thrashing was eliminated in some cases in <code>.width()</code> &amp; <code>.height()</code> APIs. Radio elements state is now updated before event handlers run. Passing data now works when triggering all events, including <code>focus</code>. A minor security fix is also included.</p>
-        <p>For more information, see the <a href="https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/">Release Notes/Changelog</a></p>
+        <p>For more information, see the <a href="https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/">Release Notes/Changelog</a>.</p>
         <hr/>
       ]]></desc>
     </category>
     <category name="Version 3.5" slug="3.5">
       <desc><![CDATA[
-        <p>Aspects of the API that were changed in the corresponding version of jQuery. Security fixes, new <code>.even()</code> &amp; <code>.odd()</code> methods; <code>jQuery.globalEval</code> now accepts context; unsuccessful HTTP script responses are no longer evaluated; performance improvements. <code>jQuery.trim</code> is now deprecated.</p>
-        <p>For more information, see the <a href="https://jquery.com/upgrade-guide/3.5/">jQuery Core 3.5 Upgrade guide</a> and the <a href="https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/">Release Notes/Changelog</a></p>
+        <p>Aspects of the API that were changed in the corresponding version of jQuery. Security fixes, including a breaking change to <code>jQuery.htmlPrefilter</code>; new <code>.even()</code> &amp; <code>.odd()</code> methods; <code>jQuery.globalEval</code> now accepts context; unsuccessful HTTP script responses are no longer evaluated; performance improvements. <code>jQuery.trim</code> is now deprecated. A <a href="https://github.com/jquery/jquery-migrate">jQuery Migrate Plugin</a> was offered to help developers with a transitional upgrade path.</p>
+        <p>For more information, see the <a href="https://jquery.com/upgrade-guide/3.5/">jQuery Core 3.5 Upgrade guide</a> and the <a href="https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/">Release Notes/Changelog</a>.</p>
+        <hr/>
+      ]]></desc>
+    </category>
+    <category name="Version 3.6" slug="3.6">
+      <desc><![CDATA[
+        <p>Aspects of the API that were changed in the corresponding version of jQuery. Returning JSON even for JSONP erroneous responses is working again, a few focus fixes.</p>
+        <p>For more information, see the <a href="https://blog.jquery.com/2021/03/02/jquery-3-6-0-released/">Release Notes/Changelog</a>.</p>
         <hr/>
       ]]></desc>
     </category>

--- a/entries/add.xml
+++ b/entries/add.xml
@@ -20,7 +20,7 @@
     </argument>
   </signature>
   <signature>
-    <added>1.3.2</added>
+    <added>1.1</added>
     <argument name="selection" type="jQuery">
       <desc>An existing jQuery object to add to the set of matched elements.</desc>
     </argument>

--- a/entries/after.xml
+++ b/entries/after.xml
@@ -34,7 +34,7 @@
     </argument>
   </signature>
   <signature>
-    <added>1.10</added>
+    <added>1.10-and-2.0</added>
     <argument name="function-html" type="Function">
       <desc>A function that returns an HTML string, DOM element(s), text node(s), or jQuery object to insert after each element in the set of matched elements. Receives the index position of the element in the set and the old HTML value of the element as arguments. Within the function, <code>this</code> refers to the current element in the set.</desc>
       <argument name="index" type="Integer" />

--- a/entries/before.xml
+++ b/entries/before.xml
@@ -35,7 +35,7 @@
     </argument>
   </signature>
    <signature>
-    <added>1.10</added>
+    <added>1.10-and-2.0</added>
     <argument name="function-html" type="Function">
       <argument name="index" type="Integer" />
       <argument name="html" type="String" />

--- a/entries/jQuery.ajax.xml
+++ b/entries/jQuery.ajax.xml
@@ -114,7 +114,7 @@ $.ajax({
         <argument name="jqXHR" type="jqXHR"/>
         <argument name="textStatus" type="String"/>
         <argument name="errorThrown" type="String"/>
-        <desc>A function to be called if the request fails. The function receives three arguments: The jqXHR (in jQuery 1.4.x, XMLHttpRequest) object, a string describing the type of error that occurred and an optional exception object, if one occurred. Possible values for the second argument (besides <code>null</code>) are <code>"timeout"</code>, <code>"error"</code>, <code>"abort"</code>, and <code>"parsererror"</code>. When an HTTP error occurs, <code>errorThrown</code> receives the textual portion of the HTTP status, such as "Not Found" or "Internal Server Error." (in HTTP/2 it may instead be an empty string) <strong>As of jQuery 1.5</strong>, the <code>error</code> setting can accept an array of functions. Each function will be called in turn.  <strong>Note:</strong> <em>This handler is not called for cross-domain script and cross-domain JSONP requests.</em> This is an <a href="/Ajax_Events/">Ajax Event</a>.</desc>
+        <desc>A function to be called if the request fails. The function receives three arguments: The jqXHR (in jQuery 1.4.x, XMLHttpRequest) object, a string describing the type of error that occurred and an optional exception object, if one occurred. Possible values for the second argument (besides <code>null</code>) are <code>"timeout"</code>, <code>"error"</code>, <code>"abort"</code>, and <code>"parsererror"</code>. When an HTTP error occurs, <code>errorThrown</code> receives the textual portion of the HTTP status, such as "Not Found" or "Internal Server Error." (in HTTP/2 it may instead be an empty string) <strong>As of jQuery 1.5</strong>, the <code>error</code> setting can accept an array of functions. Each function will be called in turn.  <strong>Note:</strong> <em>This handler is not called for cross-domain scripts and cross-domain JSONP requests.</em> This is an <a href="/Ajax_Events/">Ajax Event</a>.</desc>
       </property>
       <property default="true" name="global" type="Boolean">
         <desc>Whether to trigger global Ajax event handlers for this request. The default is <code>true</code>. Set to <code>false</code> to prevent the global handlers like <code>ajaxStart</code> or <code>ajaxStop</code> from being triggered. This can be used to control various <a href="/Ajax_Events/">Ajax Events</a>.</desc>
@@ -463,4 +463,5 @@ $.ajax({
   <category slug="version/1.5"/>
   <category slug="version/1.5.1"/>
   <category slug="version/3.5"/>
+  <category slug="version/3.6"/>
 </entry>

--- a/entries/jQuery.support.xml
+++ b/entries/jQuery.support.xml
@@ -4,10 +4,15 @@
   <signature>
     <added>1.3</added>
   </signature>
-  <desc>A collection of properties that represent the presence of different browser features or bugs. Intended for jQuery's internal use; specific properties may be removed when they are no longer needed internally to improve page startup performance. For your own project's feature-detection needs, we strongly recommend the use of an external library such as <a href="https://modernizr.com">Modernizr</a> instead of dependency on properties in <code>jQuery.support</code>.</desc>
+  <desc>A collection of properties that represent the presence of different browser features or bugs; intended for jQuery's internal use.</desc>
+  <longdesc>
+    <p>A collection of properties that represent the presence of different browser features or bugs. Intended for jQuery's internal use; specific properties may be removed when they are no longer needed internally to improve page startup performance. For your own project's feature-detection needs, we strongly recommend the use of an external library such as <a href="https://modernizr.com">Modernizr</a> instead of dependency on properties in <code>jQuery.support</code>.</p>
+    <p>As of jQuery 1.11 or 1.12, <code>jQuery.support</code> is no longer JSON-serializable; some properties point to functions that return the support test result when called. This was necessary to support lazy execution of support tests.</p>
+  </longdesc>
   <category slug="properties/global-jquery-object-properties"/>
   <category slug="utilities"/>
   <category slug="version/1.3"/>
   <category slug="version/1.5.1"/>
+  <category slug="version/1.11-and-2.1"/>
   <category slug="deprecated/deprecated-1.9"/>
 </entry>


### PR DESCRIPTION
jQuery 1.10/2.0 & 1.11/2.1 now have dedicated version categories; the same applies to 3.6. A few other version descriptions have been tweaked.

The `.add( selection )` signature is now documented to have arrived in 1.1 instead of 1.3.2. Tests for this behavior got added in https://github.com/jquery/jquery/commit/a5f9108a2109b2ed5778af860b0928d8e6b0fdd2.

A cetegory in one of `before` & `after` signatures was updated from `1.10` to `1.10-and-2.0`, fixing a broken category link.

This should fix the `spider-check` that is broken right now on GitHub Actions: https://github.com/jquery/api.jquery.com/actions/runs/4789051019/jobs/8516452787