### PR TITLE
Build: Skip checking Twitter links in the hydra crawler

### DIFF
--- a/.github/configs/hydra-config.json
+++ b/.github/configs/hydra-config.json
@@ -1,0 +1,5 @@
+{
+  "exclude_scheme_prefixes": [
+    "https://twitter.com/"
+  ]
+}

--- a/.github/workflows/spider-check.yaml
+++ b/.github/workflows/spider-check.yaml
@@ -20,9 +20,18 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'jquery' }} # skip on forks
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout hydra-link-checker
+        uses: actions/checkout@v3
         with:
           repository: jquery/hydra-link-checker
           ref: v2.0.0
+          path: hydra
+
+      # Checkout the API repo as well to provide the config for hydra-link-checker
+      - name: Checkout API repo
+        uses: actions/checkout@v3
+        with:
+          path: api
+
       - name: Run hydra-link-checker
-        run: python3 hydra.py "$MY_SITE"
+        run: python3 hydra/hydra.py "$MY_SITE" --config api/.github/configs/hydra-config.json


### PR DESCRIPTION
Twitter pages now do 302-redirects to themselves for users without a specific cookie set which trips the crawler; avoid checking Twitter links by abusing the `exclude_scheme_prefixes` option of the crawler.

Since the project only accepts options in a form of a configuration file, we also need to clone the API repo to provide such a file.