### PR TITLE
Build: add timmy emails to mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,2 +1,5 @@
 Matic Potočnik <maticpotocnik@gmail.com> <hairyfotr@gmail.com>
 Michał Gołębiowski-Owczarek <m.goleb@gmail.com>
+Timmy Willison <timmywil@users.noreply.github.com>
+Timmy Willison <timmywil@users.noreply.github.com> <4timmywil@gmail.com>
+Timmy Willison <timmywil@users.noreply.github.com> <timmywillisn@gmail.com>


### PR DESCRIPTION
An old tag used a previous email.