### PR TITLE
All: Add a 4.0 version category

### DIFF
--- a/categories.xml
+++ b/categories.xml
@@ -519,6 +519,17 @@ var files = event.originalEvent.dataTransfer.files;
         <hr/>
       ]]></desc>
     </category>
+    <category name="Version 4.0" slug="4.0">
+      <desc><![CDATA[
+        <div id="version-support-warning" class="warning"><i class="icon-info-sign"></i> <span>This is a pre-release. Behavior may change before the stable release is cut. Use with caution.</span></div>
+        <p>Aspects of the API that were changed in the corresponding version of jQuery.</p>
+        <p>Dropped support for IE &lt;11 & Edge Legacy, removed deprecated APIs, added FormData support, improved support for CSP & Trusted Types. Automatic JSONP promotion removed. Special handling of boolean attributes removed.</p>
+        <p>Callbacks & Deferred modules are now excluded from the Slim build.</p>
+        <p>jQuery is now authored in ESM.</p>
+        <p>For more information, see the <a href="https://blog.jquery.com/2024/07/17/second-beta-of-jquery-4-0-0/">Release Notes/Changelog of jQuery 4.0.0-beta.2</a>.</p>
+        <hr/>
+      ]]></desc>
+    </category>
     <category name="All" slug="all"/>
   </category>
 </categories>

--- a/categories.xml
+++ b/categories.xml
@@ -521,7 +521,7 @@ var files = event.originalEvent.dataTransfer.files;
     </category>
     <category name="Version 4.0" slug="4.0">
       <desc><![CDATA[
-        <div id="version-support-warning" class="warning"><i class="icon-info-sign"></i> <span>This is a pre-release. Behavior may change before the stable release is cut. Use with caution.</span></div>
+        <div id="version-support-warning" class="warning"><i class="icon-info-sign"></i> <span>This is a pre-release. Behavior may change before 4.0.0 final is released.</span></div>
         <p>Aspects of the API that were changed in the corresponding version of jQuery.</p>
         <p>Dropped support for IE &lt;11 & Edge Legacy, removed deprecated APIs, added FormData support, improved support for CSP & Trusted Types. Automatic JSONP promotion removed. Special handling of boolean attributes removed.</p>
         <p>Callbacks & Deferred modules are now excluded from the Slim build.</p>


### PR DESCRIPTION
I added a `4.0` category here as well. We are close to the release and I'd prefer start merging docs changes for jQuery 4.0 instead of waiting for the release. I added a banner to the category indicating it's a pre-release, we can update it if we release an RC and/or a stable release, but the docs would remain the same.

I'll base other docs PRs for 4.0 on this PR so that the category is there. For this reason, this branch is pushed to `jquery`, not my fork - otherwise I'd be only able to submit PRs on my fork or to base them on `main`.