### PR TITLE
All: Mark ajax event shorthands as deprecated in 3.5, not 3.3

### DIFF
--- a/entries/ajaxComplete-shorthand.xml
+++ b/entries/ajaxComplete-shorthand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="ajaxComplete" return="jQuery" deprecated="3.3">
+<entry type="method" name="ajaxComplete" return="jQuery" deprecated="3.5">
   <title>.ajaxComplete()</title>
   <desc>Register a handler to be called when Ajax requests complete. This is an <a href="/Ajax_Events/">AjaxEvent</a>.</desc>
   <signature>

--- a/entries/ajaxError-shorthand.xml
+++ b/entries/ajaxError-shorthand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="ajaxError" return="jQuery" deprecated="3.3">
+<entry type="method" name="ajaxError" return="jQuery" deprecated="3.5">
   <title>.ajaxError()</title>
   <desc>Register a handler to be called when Ajax requests complete with an error. This is an <a href="/Ajax_Events/">Ajax Event</a>.</desc>
   <signature>

--- a/entries/ajaxSend-shorthand.xml
+++ b/entries/ajaxSend-shorthand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="ajaxSend" return="jQuery" deprecated="3.3">
+<entry type="method" name="ajaxSend" return="jQuery" deprecated="3.5">
   <title>.ajaxSend()</title>
   <desc>Attach a function to be executed before an Ajax request is sent. This is an <a href="/Ajax_Events/">Ajax Event</a>.</desc>
   <signature>

--- a/entries/ajaxStart-shorthand.xml
+++ b/entries/ajaxStart-shorthand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="ajaxStart" return="jQuery" deprecated="3.3">
+<entry type="method" name="ajaxStart" return="jQuery" deprecated="3.5">
   <title>.ajaxStart()</title>
   <desc>Register a handler to be called when the first Ajax request begins. This is an <a href="/Ajax_Events/">Ajax Event</a>.</desc>
   <signature>

--- a/entries/ajaxStop-shorthand.xml
+++ b/entries/ajaxStop-shorthand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="ajaxStop" return="jQuery" deprecated="3.3">
+<entry type="method" name="ajaxStop" return="jQuery" deprecated="3.5">
   <title>.ajaxStop()</title>
   <desc>Register a handler to be called when all Ajax requests have completed. This is an <a href="/Ajax_Events/">Ajax Event</a>.</desc>
   <signature>

--- a/entries/ajaxSuccess-shorthand.xml
+++ b/entries/ajaxSuccess-shorthand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<entry type="method" name="ajaxSuccess" return="jQuery" deprecated="3.3">
+<entry type="method" name="ajaxSuccess" return="jQuery" deprecated="3.5">
   <title>.ajaxSuccess()</title>
   <desc>Attach a function to be executed whenever an Ajax request completes successfully. This is an <a href="/Ajax_Events/">Ajax Event</a>.</desc>
   <signature>


### PR DESCRIPTION
jQuery 3.3.0 deprecated regular event shorthands:
https://blog.jquery.com/2018/01/19/jquery-3-3-0-a-fragrant-bouquet-of-deprecations-and-is-that-a-new-feature/ The AJAX ones only got deprecated in 3.5:
https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/

Interstingly, the AJAX shorthands were already added to the `deprecated/deprecated-3.5` category, only the `deprecated` attribute was set incorrectly.