### PR TITLE
Fixing typo on Example code block

### DIFF
--- a/entries/ajaxSuccess.xml
+++ b/entries/ajaxSuccess.xml
@@ -28,25 +28,25 @@
     </code></pre>
     <p>Attach the event handler to any element:</p>
     <pre><code>
-$( document ).on( "ajaxSuccess", function() {
-  $( ".log" ).text( "Triggered ajaxSuccess handler." );
-} );
+      $( document ).on( "ajaxSuccess", function() {
+        $( ".log" ).text( "Triggered ajaxSuccess handler." );
+      } );
     </code></pre>
     <p>Now, make an Ajax request using any jQuery method:</p>
     <pre><code>
-$( ".trigger" ).on( "click", function() {
-  $( ".result" ).load( "ajax/test.html" );
-} );
+      $( ".trigger" ).on( "click", function() {
+        $( ".result" ).load( "ajax/test.html" );
+      } );
     </code></pre>
     <p>When the user clicks the element with class <code>trigger</code> and the Ajax request completes successfully, the log message is displayed.</p>
     <p>All <code>ajaxSuccess</code> handlers are invoked, regardless of what Ajax request was completed. If you must differentiate between the requests, you can use the parameters passed to the handler. Each time an <code>ajaxSuccess</code> handler is executed, it is passed the event object, the <code>XMLHttpRequest</code> object, and the settings object that was used in the creation of the request. For example, you can restrict the callback to only handling events dealing with a particular URL:</p>
     <pre><code>
-$( document ).on( "ajaxSuccess", function( event, xhr, settings ) {
-  if ( settings.url == "ajax/test.html" ) {
-    $( ".log" ).text( "Triggered ajaxSuccess handler. The Ajax response was: " +
-      xhr.responseText );
-  }
-} );
+      $( document ).on( "ajaxSuccess", function( event, xhr, settings ) {
+        if ( settings.url == "ajax/test.html" ) {
+          $( ".log" ).text( "Triggered ajaxSuccess handler. The Ajax response was: " +
+            xhr.responseText );
+        }
+      } );
     </code></pre>
     <p><strong>Note:</strong> You can get the returned Ajax contents by looking at <code>xhr.responseXML</code> or <code>xhr.responseText</code> for xml and html respectively.</p>
   </longdesc>
@@ -54,11 +54,11 @@ $( document ).on( "ajaxSuccess", function( event, xhr, settings ) {
   <note id="ajax-global-false" type="additional" data-title="ajaxSuccess"/>
   <example>
     <desc>Show a message when an Ajax request completes successfully.</desc>
-    <code><![CDATA[
-$( document ).on( "ajaxSuccess< function( event, request, settings ) {
-  $( "#msg" ).append( "<li>Successful Request!</li>" );
-} );
-]]></code>
+    <pre><code>
+      $( document ).on( "ajaxSuccess", function( event, request, settings ) {
+        $( "#msg" ).append( "<li>Successful Request!</li>" );
+      } );
+    </code></pre>
   </example>
   <category slug="ajax/global-ajax-event-handlers"/>
   <category slug="version/1.0"/>


### PR DESCRIPTION
Fixing:
- Example code block formatting and typo in example code.

Page in question: https://api.jquery.com/ajaxSuccess/

Typo " "ajaxSuccess< " found at the example section:
```
$( document ).on( "ajaxSuccess< function( event, request, settings ) {
  $( "#msg" ).append( "<li>Successful Request!</li>" );
} );
```