### PR TITLE
Build: Skip checking oembed wp-json links in the hydra crawler

### DIFF
--- a/.github/configs/hydra-config.json
+++ b/.github/configs/hydra-config.json
@@ -1,5 +1,10 @@
 {
+  "//": [
+    "2023-05: twitter.com serves broken redirect-loop",
+    "2025-04: The oembed endpoint responds HTTP 429 Too Many Requests too often; perhaps because almost every page links to one"
+  ],
   "exclude_scheme_prefixes": [
-    "https://twitter.com/"
+    "https://twitter.com/",
+    "https://api.jquery.com/wp-json/oembed/1.0/embed"
   ]
 }

--- a/.github/workflows/spider-check.yaml
+++ b/.github/workflows/spider-check.yaml
@@ -9,9 +9,11 @@ on:
   push:
     paths:
       - .github/workflows/spider-check.yaml
+      - .github/configs/hydra-config.json
   pull_request:
     paths:
       - .github/workflows/spider-check.yaml
+      - .github/configs/hydra-config.json
 
 jobs:
   spider-check:


### PR DESCRIPTION
The oembed endpoint responds HTTP 429 Too Many Requests too often; perhaps because almost every page links to one.