### PR TITLE
All: Create pages for `jQuery.Deferred.{getErrorHook,exceptionHook}`

### DIFF
--- a/categories.xml
+++ b/categories.xml
@@ -108,6 +108,12 @@
         <p>For more information, see the Release Notes/Changelog at <a href="https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/">https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/</a></p>
       ]]></desc>
     </category>
+    <category name="Deprecated 3.7" slug="deprecated-3.7">
+      <desc><![CDATA[
+        <p>All the aspects of the API that were deprecated in the corresponding version of jQuery.</p>
+        <p>For more information, see the Release Notes/Changelog at <a href="https://blog.jquery.com/2023/05/11/jquery-3-7-0-released-staying-in-order/">https://blog.jquery.com/2023/05/11/jquery-3-7-0-released-staying-in-order/</a></p>
+      ]]></desc>
+    </category>
   </category>
   <category name="Dimensions" slug="dimensions">
     <desc><![CDATA[These methods are used to get and set the CSS dimensions for the various properties.]]></desc>

--- a/entries/jQuery.Deferred.exceptionHook.xml
+++ b/entries/jQuery.Deferred.exceptionHook.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<entry type="method" name="jQuery.Deferred.exceptionHook" return="Error">
+  <title>jQuery.Deferred.exceptionHook()</title>
+  <signature>
+    <added>3.0</added>
+  </signature>
+  <desc>Handle errors produced by Deferreds.</desc>
+  <longdesc>
+    <p>This API is called every time an error is thrown inside Deferreds. By default, it only warns about errors that are more likely to be programmer errors than errors thrown due to application logic. This includes errors like <code>SyntaxError</code> or <code>ReferenceError</code>.</p>
+    <p>If you want, you can redefine the API to handle errors the way you like. The function accepts two parameters - the first one is an error thrown and the second, optional one is a "fake" error created before the handler is called so that a stack trace from before an async barrier is available. This second error is only provided if <a href="/jQuery.Deferred.getErrorHook/"><code>jQuery.Deferred.getErrorHook</code></a> is defined; see the docs for that API for more details.</p>
+    <h3>Example</h3>
+    <pre><code><![CDATA[
+// These usually indicate a programmer mistake during development,
+// warn about them ASAP rather than swallowing them by default.
+var rerrorNames = /^(Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/;
+
+// If `jQuery.Deferred.getErrorHook` is defined, `asyncError` is an error
+// captured before the async barrier to get the original error cause
+// which may otherwise be hidden.
+jQuery.Deferred.exceptionHook = function( error, asyncError ) {
+
+  if ( error && rerrorNames.test( error.name ) ) {
+    MyLoggingLibrary.log(
+      "jQuery.Deferred exception",
+      error,
+      asyncError
+    );
+  }
+};
+    ]]></code></pre>
+  </longdesc>
+  <category slug="deferred-object"/>
+  <category slug="version/3.0"/>
+</entry>

--- a/entries/jQuery.Deferred.exceptionHook.xml
+++ b/entries/jQuery.Deferred.exceptionHook.xml
@@ -7,10 +7,10 @@
   <desc>Handle errors produced by Deferreds.</desc>
   <longdesc>
     <p>This API is called every time an error is thrown inside Deferreds. By default, it only warns about errors that are more likely to be programmer errors than errors thrown due to application logic. This includes errors like <code>SyntaxError</code> or <code>ReferenceError</code>.</p>
-    <p>If you want, you can redefine the API to handle errors the way you like. The function accepts two parameters - the first one is an error thrown and the second, optional one is a "fake" error created before the handler is called so that a stack trace from before an async barrier is available. This second error is only provided if <a href="/jQuery.Deferred.getErrorHook/"><code>jQuery.Deferred.getErrorHook</code></a> is defined; see the docs for that API for more details.</p>
+    <p>The function accepts two parameters - the first one is the error thrown and the second, optional parameter is a "fake" error created before the handler is called so that a stack trace from before an async barrier is available. This second error is only provided if <a href="/jQuery.Deferred.getErrorHook/"><code>jQuery.Deferred.getErrorHook</code></a> is defined; see the docs for that API for more details.</p>
     <h3>Example</h3>
     <pre><code><![CDATA[
-// These usually indicate a programmer mistake during development,
+// These usually indicate a programmer mistake during development;
 // warn about them ASAP rather than swallowing them by default.
 var rerrorNames = /^(Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/;
 

--- a/entries/jQuery.Deferred.getErrorHook.xml
+++ b/entries/jQuery.Deferred.getErrorHook.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<entry type="method" name="jQuery.Deferred.getErrorHook" return="Error">
+  <title>jQuery.Deferred.getErrorHook()</title>
+  <signature>
+    <added>3.7</added>
+  </signature>
+  <desc>Return an Error instance with a defined stack.</desc>
+  <longdesc>
+    <div class="warning">
+      <p>Note: This API is not defined by default. It may be provided by the user and jQuery will then use it internally.</p>
+    </div>
+    <p>When <code>jQuery.Deferred.getErrorHook</code> is defined, it extends the <code>jQuery.Deferred</code> features added in jQuery 3.0 to include an error captured before the async barrier whenever a Deferred throws an exception. This makes it easier to find programming errors that occur inside Deferreds. You can find an example implementation you can copy-paste below, or you can use <a href="https://github.com/dmethvin/jquery-deferred-reporter">jquery-deferred-reporter</a> plugin.</p>
+    <pre><code>
+jQuery.Deferred.getErrorHook = function() {
+  try {
+    throw new Error( "Exception in jQuery.Deferred" );
+  } catch ( err ) {
+    return err;
+  }
+};
+    </code></pre>
+    <p>When defined, an error returned by this API is passed to <a href="/jQuery.Deferred.exceptionHook/"><code>jQuery.Deferred.exceptionHook</code></a> as the second parameter.</p>
+    <h4>Why does this API exist?</h4>
+    <p>Prior to jQuery 3.0, Deferreds would simply terminate and the browser would generate a message on the console if an exception occurred such as attempting to call an undefined method as a function (e.g., <code>myobject.missingFunction()</code>). As of version 3.0, <code>jQuery.Deferred</code> follows the Promise/A+ specification when you use the <code>.then</code> method. The spec requires all errors to be trapped by the Promise, which prevents console errors from being logged. If the user has forgotten to add a handler for rejected promises, this can result in the error being silently swallowed with no notification at all!</p>
+    <p>The native <code>Promise</code> object as implemented in the browser tracks Promise rejections and reports problems on the console. However, doing the same type of reporting in the JavaScript world is much more difficult. jQuery itself is unable to use the native Promise because jQuery.Deferred implements a superset of Promise that requires additional features for methods like <code>.done</code> or <code>.fail</code>, and because Promise is not implemented on all the platforms that jQuery supports.</p>
+  </longdesc>
+  <category slug="deferred-object"/>
+  <category slug="version/3.7"/>
+</entry>

--- a/entries/jQuery.Deferred.getErrorHook.xml
+++ b/entries/jQuery.Deferred.getErrorHook.xml
@@ -7,7 +7,7 @@
   <desc>Return an Error instance with a defined stack.</desc>
   <longdesc>
     <div class="warning">
-      <p>Note: This API is not defined by default. It may be provided by the user and jQuery will then use it internally.</p>
+      <p>Note: This API is not defined by default, but jQuery will make use of it when defined.</p>
     </div>
     <p>When <code>jQuery.Deferred.getErrorHook</code> is defined, it extends the <code>jQuery.Deferred</code> features added in jQuery 3.0 to include an error captured before the async barrier whenever a Deferred throws an exception. This makes it easier to find programming errors that occur inside Deferreds. You can find an example implementation you can copy-paste below, or you can use <a href="https://github.com/dmethvin/jquery-deferred-reporter">jquery-deferred-reporter</a> plugin.</p>
     <pre><code>

--- a/entries/jQuery.Deferred.getStackHook.xml
+++ b/entries/jQuery.Deferred.getStackHook.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<entry type="method" name="jQuery.Deferred.getStackHook" return="Error" deprecated="3.7" removed="4.0">
+  <title>jQuery.Deferred.getStackHook()</title>
+  <signature>
+    <added>3.0</added>
+  </signature>
+  <desc>Return an Error instance with a defined stack.</desc>
+  <longdesc>
+    <div class="warning">
+      <p>Note: This API has been deprecated in jQuery 3.7; please use the <a href="/jQuery.Deferred.getErrorHook/"><code>jQuery.Deferred.getErrorHook</code></a> method instead.</p>
+    </div>
+    <div class="warning">
+      <p>Note: This API is not defined by default. It may be provided by the user and jQuery will then use it internally.</p>
+    </div>
+    <p>See <a href="/jQuery.Deferred.getErrorHook/"><code>jQuery.Deferred.getErrorHook</code></a> for the context why this API was created. Initially, we advised users to assign to it a function returning an error stack:</p>
+    <pre><code>
+jQuery.Deferred.getStackHook = function() {
+  try {
+    throw new Error( "Exception in jQuery.Deferred" );
+  } catch ( err ) {
+    return err.stack; // stack property returned here
+  }
+};
+    </code></pre>
+    <p>However, when such a stack is then logged by jQuery from inside of <a href="/jQuery.Deferred.exceptionHook/"><code>jQuery.Deferred.exceptionHook</code></a>, the browser won't apply source maps. Therefore, we changed the recommendation to return the full error object itself. To make it clearer, the API was also renamed.</p>
+  </longdesc>
+  <category slug="deferred-object"/>
+  <category slug="version/3.0"/>
+  <category slug="deprecated/deprecated-3.7"/>
+</entry>


### PR DESCRIPTION
Also, create a page for the now deprecated `jQuery.Deferred.getStackHook`.

Fixes gh-1221
Fixes gh-1246

Page screenshots:
<img width="896" alt="Screenshot 2025-04-15 at 13 41 24" src="https://github.com/user-attachments/assets/b51e1e4e-a9c3-401e-b6fa-67ce25af5873" />
<img width="881" alt="Screenshot 2025-04-15 at 13 41 32" src="https://github.com/user-attachments/assets/6b7d101f-46d5-4632-8b37-a030a0afd794" />
<img width="886" alt="Screenshot 2025-04-15 at 13 41 42" src="https://github.com/user-attachments/assets/999f3498-6eb9-4a0a-ad7a-ad3528a80a8b" />
