### PR TITLE
Build: Skip checking code-of-conduct.openjsf.org & x.com in  the hydra crawler

### DIFF
--- a/.github/configs/hydra-config.json
+++ b/.github/configs/hydra-config.json
@@ -1,10 +1,14 @@
 {
   "//": [
     "2023-05: twitter.com serves broken redirect-loop",
-    "2025-04: The oembed endpoint responds HTTP 429 Too Many Requests too often; perhaps because almost every page links to one"
+    "2025-04: The oembed endpoint responds HTTP 429 Too Many Requests too often; perhaps because almost every page links to one",
+    "2026-03 code-of-conduct.openjsf.org serves 429 Too Many Requests too often",
+    "2026-03: twitter.com used to serve a broken redirect-loop and we expect x.com to be doing the same"
   ],
   "exclude_scheme_prefixes": [
     "https://twitter.com/",
-    "https://api.jquery.com/wp-json/oembed/1.0/embed"
+    "https://api.jquery.com/wp-json/oembed/1.0/embed",
+    "https://code-of-conduct.openjsf.org/",
+    "https://x.com/"
   ]
 }


### PR DESCRIPTION
We're getting 429 Too Many Requests on almost every spider-check run.

We're already skipping twitter.com, let's do the same for x.com.

Example: https://github.com/jquery/api.jquery.com/actions/runs/22923413262/job/66527539538