### PR TITLE
jQuery.ajaxTransport: Add object signature to completeCallback

### DIFF
--- a/categories.xml
+++ b/categories.xml
@@ -619,6 +619,13 @@ var files = event.originalEvent.dataTransfer.files;
         <hr/>
       ]]></desc>
     </category>
+    <category name="Version 3.8" slug="3.8">
+      <desc><![CDATA[
+        <div id="version-support-warning" class="warning"><i class="icon-info-sign"></i> <span>This version has not been released yet. Behavior may change before the final release.</span></div>
+        <p>All the aspects of the API that were added, or had a new signature added, in the corresponding version of jQuery.</p>
+        <hr/>
+      ]]></desc>
+    </category>
     <category name="Version 4.0" slug="4.0">
       <desc><![CDATA[
         <p>Aspects of the API that were changed in the corresponding version of jQuery.</p>
@@ -626,6 +633,13 @@ var files = event.originalEvent.dataTransfer.files;
         <p>Callbacks &amp; Deferred modules are now excluded from the Slim build.</p>
         <p>jQuery is now authored in ESM.</p>
         <p>For more information, see the <a href="https://jquery.com/upgrade-guide/4.0/">jQuery Core 4.0 Upgrade guide</a> and the <a href="https://blog.jquery.com/2026/01/17/jquery-4-0-0/">Release Notes/Changelog of jQuery 4.0.0</a>.</p>
+        <hr/>
+      ]]></desc>
+    </category>
+    <category name="Version 4.1" slug="4.1">
+      <desc><![CDATA[
+        <div id="version-support-warning" class="warning"><i class="icon-info-sign"></i> <span>This version has not been released yet. Behavior may change before the final release.</span></div>
+        <p>All the aspects of the API that were added, or had a new signature added, in the corresponding version of jQuery.</p>
         <hr/>
       ]]></desc>
     </category>

--- a/entries/jQuery.ajax.xml
+++ b/entries/jQuery.ajax.xml
@@ -292,6 +292,9 @@ jqxhr.always(function() {
         <code>responseXML</code> and/or <code>responseText</code> when the underlying request responded with xml and/or text, respectively
       </li>
       <li>
+        <code>responseURL</code> (<strong>as of jQuery 4.1</strong>) is the final URL of the response after any redirects, when the underlying transport reports it. For XMLHttpRequest-based requests in modern browsers, this mirrors <code>XMLHttpRequest.responseURL</code>; for script, JSONP, aborted, or otherwise unsupported requests it is <code>undefined</code>.
+      </li>
+      <li>
         <code>status</code>
       </li>
       <li>
@@ -464,4 +467,5 @@ $.ajax({
   <category slug="version/1.5.1"/>
   <category slug="version/3.5"/>
   <category slug="version/3.6"/>
+  <category slug="version/4.1"/>
 </entry>

--- a/entries/jQuery.ajaxTransport.xml
+++ b/entries/jQuery.ajaxTransport.xml
@@ -40,9 +40,9 @@ $.ajaxTransport( dataType, function( options, originalOptions, jqXHR ) {
       <li><code>headers</code> is an object of (key-value) request headers that the transport can transmit if it supports it</li>
       <li><code>completeCallback</code> is the callback used to notify Ajax of the completion of the request</li>
     </ul>
-    <p><code>completeCallback</code> has the following signature:</p>
+    <p>In jQuery 3.8, 4.1 or newer <code>completeCallback</code> has the following signature:</p>
     <pre><code>
-function( status, statusText, responses, headers ) {}
+function( { status, statusText, responses, headers } ) {}
     </code></pre>
     <p>where:</p>
     <ul>
@@ -51,6 +51,11 @@ function( status, statusText, responses, headers ) {}
       <li><code>responses</code> (Optional) is An object containing dataType/value that contains the response in all the formats the transport could provide (for instance, a native XMLHttpRequest object would set responses to <code>{ xml: XMLData, text: textData }</code> for a response that is an XML document)</li>
       <li><code>headers</code> (Optional) is a string containing all the response headers if the transport has access to them (akin to what <code>XMLHttpRequest.getAllResponseHeaders()</code> would provide).</li>
     </ul>
+    <p>An older, positional-arguments form is also supported:</p>
+    <pre><code>
+function( status, statusText, responses, headers ) {}
+    </code></pre>
+    <p>The parameters have the same meaning as the object properties described above. Both calling conventions are supported; jQuery detects which one is used by checking whether the first argument is an object.</p>
     <p>Just like prefilters, a transport's factory function can be attached to a specific dataType:</p>
     <pre><code>
 $.ajaxTransport( "script", function( options, originalOptions, jqXHR ) {
@@ -70,7 +75,11 @@ $.ajaxTransport( "image", function( s ) {
             var statusText = ( status === 200 ) ? "success" : "error",
               tmp = image;
             image = image.onreadystatechange = image.onerror = image.onload = null;
-            callback( status, statusText, { image: tmp } );
+            callback( {
+              status: status,
+              statusText: statusText,
+              responses: { image: tmp }
+            } );
           }
         }
         image.onreadystatechange = image.onload = function() {
@@ -128,4 +137,6 @@ jQuery.ajaxSetup({
   </longdesc>
   <category slug="ajax/low-level-interface"/>
   <category slug="version/1.5"/>
+  <category slug="version/3.8"/>
+  <category slug="version/4.1"/>
 </entry>

--- a/entries/jQuery.ajaxTransport.xml
+++ b/entries/jQuery.ajaxTransport.xml
@@ -40,7 +40,7 @@ $.ajaxTransport( dataType, function( options, originalOptions, jqXHR ) {
       <li><code>headers</code> is an object of (key-value) request headers that the transport can transmit if it supports it</li>
       <li><code>completeCallback</code> is the callback used to notify Ajax of the completion of the request</li>
     </ul>
-    <p>In jQuery 3.8, 4.1 or newer <code>completeCallback</code> accepts a single params object:</p>
+    <p>As of jQuery 3.8 and 4.1 (excluding jQuery 4.0), <code>completeCallback</code> accepts a single params object:</p>
     <pre><code>
 function( params ) {}
     </code></pre>
@@ -50,7 +50,7 @@ function( params ) {}
       <li><code>statusText</code> is the statusText of the response.</li>
       <li><code>responses</code> (Optional) is An object containing dataType/value that contains the response in all the formats the transport could provide (for instance, a native XMLHttpRequest object would set responses to <code>{ xml: XMLData, text: textData }</code> for a response that is an XML document)</li>
       <li><code>headers</code> (Optional) is a string containing all the response headers if the transport has access to them (akin to what <code>XMLHttpRequest.getAllResponseHeaders()</code> would provide).</li>
-      <li><code>responseURL</code> (Optional, <strong>as of jQuery 4.1</strong>) is the final URL of the response after any redirects, if the transport has access to it (akin to what <code>XMLHttpRequest.responseURL</code> would provide). It is exposed on the jqXHR object as <code>jqXHR.responseURL</code>.</li>
+      <li><code>responseURL</code> (Optional) is the final URL of the response after any redirects, if the transport has access to it (akin to what <code>XMLHttpRequest.responseURL</code> would provide). It is exposed on the jqXHR object as <code>jqXHR.responseURL</code>. <strong>Added in jQuery 4.1.</strong></li>
     </ul>
     <p>An older, positional-arguments form is also supported, but limited to the following four parameters:</p>
     <pre><code>

--- a/entries/jQuery.ajaxTransport.xml
+++ b/entries/jQuery.ajaxTransport.xml
@@ -40,17 +40,23 @@ $.ajaxTransport( dataType, function( options, originalOptions, jqXHR ) {
       <li><code>headers</code> is an object of (key-value) request headers that the transport can transmit if it supports it</li>
       <li><code>completeCallback</code> is the callback used to notify Ajax of the completion of the request</li>
     </ul>
-    <p><code>completeCallback</code> has the following signature:</p>
+    <p>In jQuery 3.8, 4.1 or newer <code>completeCallback</code> accepts a single params object:</p>
     <pre><code>
-function( status, statusText, responses, headers ) {}
+function( params ) {}
     </code></pre>
-    <p>where:</p>
+    <p>with the following properties:</p>
     <ul>
       <li><code>status</code> is the HTTP status code of the response, like  200 for a typical success, or 404 for when the resource is not found.</li>
       <li><code>statusText</code> is the statusText of the response.</li>
       <li><code>responses</code> (Optional) is An object containing dataType/value that contains the response in all the formats the transport could provide (for instance, a native XMLHttpRequest object would set responses to <code>{ xml: XMLData, text: textData }</code> for a response that is an XML document)</li>
       <li><code>headers</code> (Optional) is a string containing all the response headers if the transport has access to them (akin to what <code>XMLHttpRequest.getAllResponseHeaders()</code> would provide).</li>
+      <li><code>responseURL</code> (Optional, <strong>as of jQuery 4.1</strong>) is the final URL of the response after any redirects, if the transport has access to it (akin to what <code>XMLHttpRequest.responseURL</code> would provide). It is exposed on the jqXHR object as <code>jqXHR.responseURL</code>.</li>
     </ul>
+    <p>An older, positional-arguments form is also supported, but limited to the following four parameters:</p>
+    <pre><code>
+function( status, statusText, responses, headers ) {}
+    </code></pre>
+    <p>The parameters have the same meaning as the object properties described above. Both calling conventions are supported; jQuery detects which one is used by checking whether the first argument is an object.</p>
     <p>Just like prefilters, a transport's factory function can be attached to a specific dataType:</p>
     <pre><code>
 $.ajaxTransport( "script", function( options, originalOptions, jqXHR ) {
@@ -70,7 +76,11 @@ $.ajaxTransport( "image", function( s ) {
             var statusText = ( status === 200 ) ? "success" : "error",
               tmp = image;
             image = image.onreadystatechange = image.onerror = image.onload = null;
-            callback( status, statusText, { image: tmp } );
+            callback( {
+              status: status,
+              statusText: statusText,
+              responses: { image: tmp }
+            } );
           }
         }
         image.onreadystatechange = image.onload = function() {
@@ -128,4 +138,6 @@ jQuery.ajaxSetup({
   </longdesc>
   <category slug="ajax/low-level-interface"/>
   <category slug="version/1.5"/>
+  <category slug="version/3.8"/>
+  <category slug="version/4.1"/>
 </entry>


### PR DESCRIPTION
This will be supported in jQuery `>=3.8 <4 || >=4.1`.

### Docs

#### Before

<img width="839" height="365" alt="Screenshot 2026-03-30 at 23 58 32" src="https://github.com/user-attachments/assets/e7f6639b-17ae-4f13-8c38-91e6508ec550" />

#### After

<img width="841" height="517" alt="Screenshot 2026-03-31 at 21 36 23" src="https://github.com/user-attachments/assets/39d96fe2-9bbe-4b7a-b30b-439dfafdc50a" />

### Example

#### Before

<img width="843" height="583" alt="Screenshot 2026-03-31 at 00 00 32" src="https://github.com/user-attachments/assets/6d3ccd8f-ab1f-4bfc-8b78-1fe2a40dc296" />

#### After

<img width="842" height="641" alt="Screenshot 2026-03-31 at 00 00 39" src="https://github.com/user-attachments/assets/3d3f4b49-0ee9-48c3-bc33-1cf6983e9b9c" />

### New category (4.1)

<img width="875" height="306" alt="Screenshot 2026-03-30 at 23 50 29" src="https://github.com/user-attachments/assets/62364ffd-da0e-491d-bae4-3104fa5fb5e3" />